### PR TITLE
Update publish workflow and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,59 +3,28 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: npm
-    directory: /examples/01-hello-world
+    directories:
+      - "/"
+      - "/packages/*"
+      - "/examples/*"
     schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/02-crud-api
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/03-testing
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/04-guards
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/05-middleware
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/06-queues
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/07-scheduled-tasks
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /examples/08-openapi
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /packages/core
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /packages/testing
-    schedule:
-      interval: daily
+      interval: monthly
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-non-major:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      major:
+        patterns: ["*"]
+        update-types: ["major"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,8 @@ name: Publish
 
 on:
   push:
-    tags:
-      - "stratal@*"
-      - "@stratal/testing@*"
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}
@@ -19,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -27,6 +27,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Enable Corepack
         run: corepack enable
@@ -43,11 +45,14 @@ jobs:
         run: |
           yarn workspace stratal build
           yarn workspace @stratal/testing build
+          yarn workspace @stratal/framework build
+          yarn workspace @stratal/seeders build
 
-      - name: Publish to npm
-        run: yarn release
-
-      - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --generate-notes""
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          version: yarn version
+          publish: yarn release
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ yarn install
 packages/
   core/       # stratal — core framework (DI, modules, routing, queues, storage, email, i18n)
   testing/    # @stratal/testing — test utilities, mocks, and factories
+  framework/  # @stratal/framework — auth, database ORM (ZenStack), RBAC (Casbin), guards
+  seeders/    # @stratal/seeders — CLI tool for database seeding
 ```
 
 ## Development Workflow
@@ -40,6 +42,8 @@ yarn lint:fix
 # Type check
 yarn workspace stratal typecheck
 yarn workspace @stratal/testing typecheck
+yarn workspace @stratal/framework typecheck
+yarn workspace @stratal/seeders typecheck
 
 # Run tests
 yarn workspace stratal test
@@ -64,7 +68,7 @@ The repo uses [husky](https://typicode.github.io/husky/) + [lint-staged](https:/
 
 2. **Follow existing patterns** — the codebase uses decorators, Symbol-based DI tokens, and a module-based architecture. Look at existing code for reference.
 
-3. **Add a changeset** — before committing, run:
+3. **Add a changeset** — every PR with user-facing changes **must** include a changeset. Run:
 
    ```bash
    yarn changeset
@@ -77,7 +81,10 @@ The repo uses [husky](https://typicode.github.io/husky/) + [lint-staged](https:/
    - **minor** — new features, new exports, non-breaking additions
    - **major** — breaking changes to public API
 
-   Changesets are consumed during the release process to automatically bump versions and generate changelogs.
+   **When a changeset is not needed:**
+   - Documentation-only changes
+   - CI/tooling changes that don't affect published packages
+   - Changes to private packages (e.g., the root `stratal-monorepo`)
 
 ## Code Style
 
@@ -104,7 +111,7 @@ The repo uses [husky](https://typicode.github.io/husky/) + [lint-staged](https:/
 ## Pull Requests
 
 - CI runs **lint**, **typecheck**, **test**, and **build** on every PR.
-- Include a changeset unless the change is docs-only or CI-only.
+- Include a changeset for any PR that affects published package code.
 - Keep PRs focused — one feature or fix per PR where possible.
 
 ## License


### PR DESCRIPTION
- **Publish workflow**: Switch from tag-based triggers to `changesets/action` on pushes to `main`, enabling automated Release PRs and publishing. Also builds `framework` and `seeders` packages, adds `fetch-depth: 0` for full git history, and grants `pull-requests: write` permission.
- **Dependabot**: Consolidate per-directory npm entries into a single config using `directories` glob patterns, switch from daily to monthly schedule, group non-major updates together, and add commit-message prefixes and labels.
- **CONTRIBUTING.md**: Document `framework` and `seeders` packages, clarify changeset requirements, and add typecheck commands for the new packages.

## Test plan

- [] Verify the publish workflow triggers correctly on push to `main`
- [] Confirm `changesets/action` creates Release PRs and publishes packages as expected
- [ ] Verify dependabot picks up the new grouped configuration and monthly schedule
