### PR TITLE
refactor(framework)!: rename AuthModule.withRootAsync to forRootAsync

### DIFF
--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -257,7 +257,7 @@ Register jobs in `@Module({ jobs: [DailyReportJob] })`. Add matching cron trigge
 | StorageModule | `stratal/storage` | `.forRoot({ storage, defaultStorageDisk })` | S3-compatible file storage |
 | I18nModule | `stratal/i18n` | `.forRoot({ defaultLocale, messages })` | Type-safe translations |
 | QueueModule | `stratal/queue` | `.forRootAsync(...)` | Queue producer/consumer |
-| AuthModule | `@stratal/framework/auth` | `.withRootAsync(...)` | Better Auth integration |
+| AuthModule | `@stratal/framework/auth` | `.forRootAsync(...)` | Better Auth integration |
 | DatabaseModule | `@stratal/framework/database` | `.forRoot(config)` / `.forRootAsync(...)` | ZenStack ORM multi-connection |
 | RbacModule | `@stratal/framework/rbac` | `.forRoot(options)` / `.forRootAsync(...)` | Casbin RBAC |
 
@@ -350,7 +350,7 @@ import { AuthContext } from '@stratal/framework/context'
 
 @Module({
   imports: [
-    AuthModule.withRootAsync({
+    AuthModule.forRootAsync({
       inject: [DI_TOKENS.Database, CONFIG_TOKENS.ConfigService],
       useFactory: (db, config) => createAuthOptions(db, config),
     }),

--- a/.agents/skills/stratal/references/framework-auth.md
+++ b/.agents/skills/stratal/references/framework-auth.md
@@ -9,7 +9,7 @@ npm install better-auth @better-auth/core    # required peer deps for auth
 
 ## AuthModule Setup
 
-`AuthModule.withRootAsync()` registers the Better Auth integration:
+`AuthModule.forRootAsync()` registers the Better Auth integration:
 
 ```typescript
 import { AuthModule } from '@stratal/framework/auth'
@@ -19,7 +19,7 @@ import { type BetterAuthOptions } from 'better-auth'
 
 @Module({
   imports: [
-    AuthModule.withRootAsync({
+    AuthModule.forRootAsync({
       inject: [DI_TOKENS.Database, CONFIG_TOKENS.ConfigService],
       useFactory: (db, config) => createAuthOptions(db, config),
     }),
@@ -31,7 +31,7 @@ export class AppModule {}
 **Signature:**
 
 ```typescript
-static withRootAsync<TOptions extends BetterAuthOptions>(
+static forRootAsync<TOptions extends BetterAuthOptions>(
   options: AsyncModuleOptions<TOptions>
 ): DynamicModule
 ```

--- a/.changeset/rename-auth-module-with-root-async.md
+++ b/.changeset/rename-auth-module-with-root-async.md
@@ -1,0 +1,13 @@
+---
+"@stratal/framework": patch
+---
+
+Rename `AuthModule.withRootAsync` to `AuthModule.forRootAsync` for consistency with core framework naming conventions
+
+### Breaking Changes
+
+- **@stratal/framework**: `AuthModule.withRootAsync()` has been renamed to `AuthModule.forRootAsync()`. Update all usages:
+  ```diff
+  - AuthModule.withRootAsync({ ... })
+  + AuthModule.forRootAsync({ ... })
+  ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The project is ESM-only (`"type": "module"`). Output goes to `dist/` with `.js`,
 ### Framework Modules (`packages/framework`)
 
 - **DatabaseModule** — ZenStack ORM with multiple named connections, plugin system (ErrorHandler, EventEmitter, SchemaSwitcher), and augmentable `DatabaseSchemaRegistry`/`DefaultDatabaseConnection` interfaces for type-safe access. Uses `@InjectDB(name)` decorator for named connection injection.
-- **AuthModule** — Better Auth integration with session verification middleware pipeline. Provides `AuthContext` (request-scoped) and `AuthService`. Configured via `AuthModule.withRootAsync()`.
+- **AuthModule** — Better Auth integration with session verification middleware pipeline. Provides `AuthContext` (request-scoped) and `AuthService`. Configured via `AuthModule.forRootAsync()`.
 - **RbacModule** — Casbin-based RBAC with ZenStack database adapter. Provides `CasbinService` (request-scoped) for permission checks, role management, and `getPermissionsForUserAsCasbinJs()` for frontend.
 - **AuthGuard** — Guard factory for authentication and scoped authorization. Checks `AuthContext.isAuthenticated()` and optionally `CasbinService.hasAnyPermission()`.
 - **Factory** — Abstract base class for test data factories with `@faker-js/faker` integration and `Sequence` generator.

--- a/examples/11-auth/README.md
+++ b/examples/11-auth/README.md
@@ -4,7 +4,7 @@ Session-based authentication with Better Auth and `@stratal/framework`.
 
 ## What it demonstrates
 
-- `AuthModule.withRootAsync({ inject, useFactory })` for configuring Better Auth
+- `AuthModule.forRootAsync({ inject, useFactory })` for configuring Better Auth
 - `AuthContext` injection via `DI_TOKENS.AuthContext` — `getUserId()`, `isAuthenticated()`, `requireUserId()`
 - `AuthGuard()` factory for protecting routes (returns 401 if unauthenticated)
 - Module augmentation for `StratalEnv` with `DB` and `BETTER_AUTH_SECRET`
@@ -73,6 +73,6 @@ curl http://localhost:8787/api/profile
 - [`src/auth/auth.config.ts`](src/auth/auth.config.ts) - Better Auth options factory
 - [`src/auth/auth.controller.ts`](src/auth/auth.controller.ts) - AuthController proxying requests to Better Auth handler
 - [`src/auth/auth.module.ts`](src/auth/auth.module.ts) - AuthModule registering the controller
-- [`src/app.module.ts`](src/app.module.ts) - `AuthModule.withRootAsync()` configuration
+- [`src/app.module.ts`](src/app.module.ts) - `AuthModule.forRootAsync()` configuration
 - [`src/profile/profile.controller.ts`](src/profile/profile.controller.ts) - Protected route using `AuthGuard()` and `AuthContext`
 - [`src/public/public.controller.ts`](src/public/public.controller.ts) - Unprotected route

--- a/examples/11-auth/src/app.module.ts
+++ b/examples/11-auth/src/app.module.ts
@@ -10,7 +10,7 @@ import { PublicModule } from './public/public.module'
 
 @Module({
   imports: [
-    CoreAuthModule.withRootAsync({
+    CoreAuthModule.forRootAsync({
       inject: [DI_TOKENS.CloudflareEnv],
       useFactory: (env: StratalEnv) => createAuthOptions(env),
     }),

--- a/examples/13-rbac/src/app.module.ts
+++ b/examples/13-rbac/src/app.module.ts
@@ -21,7 +21,7 @@ import { RolesModule } from './roles/roles.module'
       inject: [DI_TOKENS.CloudflareEnv],
       useFactory: (env: StratalEnv) => createDatabaseConfig(env),
     }),
-    CoreAuthModule.withRootAsync({
+    CoreAuthModule.forRootAsync({
       inject: [DI_TOKENS.CloudflareEnv, DI_TOKENS.Database],
       useFactory: (env: StratalEnv, db: DatabaseService) => createAuthOptions(env, db),
     }),

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -65,7 +65,10 @@ import { RbacModule } from '@stratal/framework/rbac'
     DatabaseModule.forRoot({
       connections: [{ name: 'default', connectionString: 'DATABASE_URL' }],
     }),
-    AuthModule.forRoot(),
+    AuthModule.forRootAsync({
+      inject: [],
+      useFactory: () => ({ /* Better Auth options */ }),
+    }),
     RbacModule.forRoot({ model: MODEL }),
   ],
 })

--- a/packages/framework/src/auth/auth.module.ts
+++ b/packages/framework/src/auth/auth.module.ts
@@ -2,13 +2,13 @@
  * Auth Module
  *
  * Provides configurable authentication using Better Auth.
- * Use `withRootAsync` to configure Better Auth options from the application layer.
+ * Use `forRootAsync` to configure Better Auth options from the application layer.
  *
  * @example
  * ```typescript
  * @Module({
  *   imports: [
- *     AuthModule.withRootAsync({
+ *     AuthModule.forRootAsync({
  *       inject: [DI_TOKENS.Database, CONFIG_TOKENS.ConfigService],
  *       useFactory: (db, config) => createAuthOptions(db, config)
  *     })
@@ -51,7 +51,7 @@ export class AuthModule implements MiddlewareConfigurable {
   /**
    * Configure AuthModule with async options factory
    */
-  static withRootAsync<TOptions extends BetterAuthOptions>(
+  static forRootAsync<TOptions extends BetterAuthOptions>(
     options: AsyncModuleOptions<TOptions>
   ): DynamicModule {
     return {

--- a/packages/framework/src/auth/services/auth.service.ts
+++ b/packages/framework/src/auth/services/auth.service.ts
@@ -9,7 +9,7 @@ import { getErrorHandlerConfig } from '../utils'
  * AuthService
  *
  * Base authentication service using Better Auth.
- * Configured via AuthModule.withRootAsync() from the application layer.
+ * Configured via AuthModule.forRootAsync() from the application layer.
  *
  * **Extensibility:**
  * Extend this class in application layer to add custom methods.

--- a/packages/framework/test/fixtures/app.module.ts
+++ b/packages/framework/test/fixtures/app.module.ts
@@ -38,7 +38,7 @@ import { RBAC_MODEL } from './rbac-model'
         ],
       }),
     }),
-    AuthModule.withRootAsync({
+    AuthModule.forRootAsync({
       inject: [DI_TOKENS.Database],
       useFactory: (db: DatabaseService) =>
         createTestAuthOptions(db),

--- a/packages/zenstack-plugin/README.md
+++ b/packages/zenstack-plugin/README.md
@@ -47,11 +47,9 @@ npx skills add strataljs/stratal
 
 ## Quick Start
 
-Import the plugin attribute and configure the plugin in your `schema.zmodel`:
+Configure the plugin in your `schema.zmodel`:
 
 ```zmodel
-import "@stratal/zenstack-plugin/plugin.zmodel"
-
 plugin stratal {
   provider = "@stratal/zenstack-plugin"
   output   = "./src/generated"


### PR DESCRIPTION
## Summary
Renames `AuthModule.withRootAsync()` to `AuthModule.forRootAsync()` for consistency with the naming convention used by all other dynamic modules (`DatabaseModule.forRootAsync`, `RbacModule.forRootAsync`, etc.).

## How to Test
- Search for `withRootAsync` across the codebase — should return zero results
- Verify `AuthModule.forRootAsync()` works in examples and test fixtures
- Run `yarn workspace @stratal/framework typecheck`

## Breaking Changes
- `AuthModule.withRootAsync()` has been renamed to `AuthModule.forRootAsync()`
- Update all imports: replace `.withRootAsync(` with `.forRootAsync(`