### PR TITLE
refactor(core): remove default CORS middleware from HonoApp

### DIFF
--- a/.changeset/remove-default-cors-middleware.md
+++ b/.changeset/remove-default-cors-middleware.md
@@ -1,0 +1,9 @@
+---
+"stratal": patch
+---
+
+Remove default CORS middleware from HonoApp
+
+### Breaking Changes
+
+- **stratal**: `HonoApp` no longer applies `cors()` middleware by default. If your application relies on the built-in CORS handling, add it explicitly via a custom middleware in your module's `configure()` method or by registering it globally.

--- a/packages/core/src/router/hono-app.ts
+++ b/packages/core/src/router/hono-app.ts
@@ -1,5 +1,4 @@
 import type { Context, MiddlewareHandler } from 'hono'
-import { cors } from 'hono/cors'
 import type { Container } from '../di/container'
 import { DI_TOKENS } from '../di/tokens'
 import { getHttpStatus, type GlobalErrorHandler } from '../errors'
@@ -130,7 +129,6 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
   }
 
   private setupGlobalMiddleware(): void {
-    this.nativeUse('*', cors() as MiddlewareHandler<RouterEnv>)
     this.nativeUse('*', createLoggerMiddleware(this._logger) as MiddlewareHandler<RouterEnv>)
     this.onError((err, c) => {
       const requestContainer = c.get(ROUTER_CONTEXT_KEYS.REQUEST_CONTAINER)


### PR DESCRIPTION
## Summary

Remove the built-in `cors()` middleware that was automatically applied to all routes in `HonoApp`. Applications should now explicitly configure CORS if needed, giving full control over CORS policy.

## How to Test

- Verify no default CORS headers are returned without explicit CORS configuration
- Add CORS middleware manually via `configure()` and confirm it works as expected

## Breaking Changes

- `HonoApp` no longer applies `cors()` middleware by default. Add it explicitly via a custom middleware in your module's `configure()` method or by registering it globally.