### PR TITLE
refactor(tokens): standardize symbol tokens to use 'stratal' namespace

### DIFF
--- a/.changeset/update-symbol-tokens-namespace.md
+++ b/.changeset/update-symbol-tokens-namespace.md
@@ -1,0 +1,6 @@
+---
+"stratal": patch
+"@stratal/framework": patch
+---
+
+Update symbol tokens to use 'stratal' namespace for consistency across modules

--- a/packages/core/src/cache/cache.tokens.ts
+++ b/packages/core/src/cache/cache.tokens.ts
@@ -1,5 +1,5 @@
 export const CACHE_TOKENS = {
-  CacheService: Symbol.for('CacheService'),
+  CacheService: Symbol.for('stratal:cache:service'),
 } as const
 
 export type CacheToken = (typeof CACHE_TOKENS)[keyof typeof CACHE_TOKENS]

--- a/packages/core/src/config/__tests__/register-as.spec.ts
+++ b/packages/core/src/config/__tests__/register-as.spec.ts
@@ -3,9 +3,9 @@ import { DI_TOKENS } from '../../di/tokens'
 import { registerAs } from '../register-as'
 
 describe('registerAs', () => {
-  it('should return object with KEY = Symbol.for("CONFIG:namespace")', () => {
+  it('should return object with KEY = Symbol.for("stratal:config:namespace")', () => {
     const config = registerAs('database', () => ({ url: 'test' }))
-    expect(config.KEY).toBe(Symbol.for('CONFIG:database'))
+    expect(config.KEY).toBe(Symbol.for('stratal:config:database'))
   })
 
   it('should set namespace property', () => {
@@ -24,8 +24,8 @@ describe('registerAs', () => {
     const dbConfig = registerAs('database', () => ({}))
     const emailConfig = registerAs('email', () => ({}))
     expect(dbConfig.KEY).not.toBe(emailConfig.KEY)
-    expect(dbConfig.KEY).toBe(Symbol.for('CONFIG:database'))
-    expect(emailConfig.KEY).toBe(Symbol.for('CONFIG:email'))
+    expect(dbConfig.KEY).toBe(Symbol.for('stratal:config:database'))
+    expect(emailConfig.KEY).toBe(Symbol.for('stratal:config:email'))
   })
 
   describe('asProvider()', () => {
@@ -35,7 +35,7 @@ describe('registerAs', () => {
       const provider = config.asProvider()
 
       expect(provider).toEqual({
-        provide: Symbol.for('CONFIG:database'),
+        provide: Symbol.for('stratal:config:database'),
         useFactory: factory,
         inject: [DI_TOKENS.CloudflareEnv],
       })

--- a/packages/core/src/config/config.tokens.ts
+++ b/packages/core/src/config/config.tokens.ts
@@ -1,3 +1,3 @@
 export const CONFIG_TOKENS = {
-	ConfigService: Symbol.for('ConfigService'),
+	ConfigService: Symbol.for('stratal:config:service'),
 } as const

--- a/packages/core/src/config/register-as.ts
+++ b/packages/core/src/config/register-as.ts
@@ -6,7 +6,7 @@ import type { FactoryProvider } from '../module/types'
  * Configuration namespace registration result
  */
 export interface ConfigNamespace<TKey extends string, TEnv, TConfig extends object> {
-  /** Auto-derived injection token (e.g., 'database' -> Symbol('CONFIG:database')) */
+  /** Auto-derived injection token (e.g., 'database' -> Symbol('stratal:config:database')) */
   readonly KEY: InjectionToken<TConfig>
   /** The namespace key */
   readonly namespace: TKey
@@ -35,7 +35,7 @@ export interface ConfigNamespace<TKey extends string, TEnv, TConfig extends obje
  *   maxConnections: parseInt(env.DATABASE_MAX_CONNECTIONS || '10'),
  * }))
  *
- * // Auto-generates: databaseConfig.KEY = Symbol('CONFIG:database')
+ * // Auto-generates: databaseConfig.KEY = Symbol('stratal:config:database')
  *
  * // Usage in module:
  * // Option 1: Manual provider
@@ -54,7 +54,7 @@ export function registerAs<TKey extends string, TEnv, TConfig extends object>(
   namespace: TKey,
   factory: (env: TEnv) => TConfig
 ): ConfigNamespace<TKey, TEnv, TConfig> {
-  const KEY = Symbol.for(`CONFIG:${namespace}`) as InjectionToken<TConfig>
+  const KEY = Symbol.for(`stratal:config:${namespace}`) as InjectionToken<TConfig>
 
   return {
     KEY,

--- a/packages/core/src/di/tokens.ts
+++ b/packages/core/src/di/tokens.ts
@@ -2,33 +2,33 @@
  * Token for the Container instance
  * Used for injecting the Container into services that need dynamic resolution
  */
-export const CONTAINER_TOKEN = Symbol.for('di:Container')
+export const CONTAINER_TOKEN = Symbol.for('stratal:di:container')
 
 export const DI_TOKENS = {
   // Cloudflare
-  CloudflareEnv: Symbol.for('CloudflareEnv'),
-  ExecutionContext: Symbol.for('ExecutionContext'),
+  CloudflareEnv: Symbol.for('stratal:cloudflare:env'),
+  ExecutionContext: Symbol.for('stratal:execution:context'),
 
   // Infrastructure
   Container: CONTAINER_TOKEN,
-  Application: Symbol.for('Application'),
-  ModuleRegistry: Symbol.for('ModuleRegistry'),
-  ErrorHandler: Symbol.for('ErrorHandler'),
-  Database: Symbol.for('DatabaseService'),
-  Queue: Symbol.for('QueueManager'),
-  ConsumerRegistry: Symbol.for('ConsumerRegistry'),
-  Cron: Symbol.for('CronManager'),
-  EventRegistry: Symbol.for('EventRegistry'),
+  Application: Symbol.for('stratal:application'),
+  ModuleRegistry: Symbol.for('stratal:module:registry'),
+  ErrorHandler: Symbol.for('stratal:error:handler'),
+  Database: Symbol.for('stratal:database:service'),
+  Queue: Symbol.for('stratal:queue:manager'),
+  ConsumerRegistry: Symbol.for('stratal:consumer:registry'),
+  Cron: Symbol.for('stratal:cron:manager'),
+  EventRegistry: Symbol.for('stratal:event:registry'),
 
   // Context
   /**
    * AuthContext: Use for services that need user authentication (userId).
    */
-  AuthContext: Symbol.for('AuthContext'),
+  AuthContext: Symbol.for('stratal:auth:context'),
 
   // Workers
-  DurableObjectState: Symbol.for('DurableObjectState'),
-  DurableObjectId: Symbol.for('DurableObjectId'),
+  DurableObjectState: Symbol.for('stratal:durable:object:state'),
+  DurableObjectId: Symbol.for('stratal:durable:object:id'),
 } as const
 
 export type DIToken = typeof DI_TOKENS[keyof typeof DI_TOKENS]

--- a/packages/core/src/email/email.tokens.ts
+++ b/packages/core/src/email/email.tokens.ts
@@ -12,26 +12,26 @@ export const EMAIL_TOKENS = {
   /**
    * Email module configuration options
    */
-  Options: Symbol.for('EmailModuleOptions'),
+  Options: Symbol.for('stratal:email:options'),
 
   /**
    * Main email service - facade for sending emails via queues
    */
-  EmailService: Symbol.for('EmailService'),
+  EmailService: Symbol.for('stratal:email:service'),
 
   /**
    * Factory for creating email provider instances based on configuration
    */
-  EmailProviderFactory: Symbol.for('EmailProviderFactory'),
+  EmailProviderFactory: Symbol.for('stratal:email:provider:factory'),
 
   /**
    * Email provider interface - abstracts provider implementation
    */
-  EmailProvider: Symbol.for('EmailProvider'),
+  EmailProvider: Symbol.for('stratal:email:provider'),
 
   /**
    * Queue sender for email dispatch.
    * Bound via EmailModule.forRoot({ queue: 'queue-name' })
    */
-  EmailQueue: Symbol.for('email:Queue'),
+  EmailQueue: Symbol.for('stratal:email:queue'),
 } as const

--- a/packages/core/src/i18n/i18n.tokens.ts
+++ b/packages/core/src/i18n/i18n.tokens.ts
@@ -5,9 +5,9 @@
 
 export const I18N_TOKENS = {
   /** MessageLoaderService - loads and caches locale messages */
-  MessageLoader: Symbol.for('I18nModule.MessageLoader'),
+  MessageLoader: Symbol.for('stratal:i18n:message:loader'),
   /** I18nService - request-scoped translation service */
-  I18nService: Symbol.for('I18nModule.I18nService'),
+  I18nService: Symbol.for('stratal:i18n:service'),
   /** I18nModuleOptions - configuration options from forRoot() */
-  Options: Symbol.for('I18nModule.Options')
+  Options: Symbol.for('stratal:i18n:options')
 } as const

--- a/packages/core/src/logger/logger.tokens.ts
+++ b/packages/core/src/logger/logger.tokens.ts
@@ -8,25 +8,25 @@ export const LOGGER_TOKENS = {
   /**
    * Main logger service facade
    */
-  LoggerService: Symbol.for('Logger.LoggerService'),
+  LoggerService: Symbol.for('stratal:logger:service'),
 
   /**
    * Log formatter (JSON or Pretty)
    */
-  Formatter: Symbol.for('Logger.Formatter'),
+  Formatter: Symbol.for('stratal:logger:formatter'),
 
   /**
    * Array of active transports
    */
-  Transports: Symbol.for('Logger.Transports'),
+  Transports: Symbol.for('stratal:logger:transports'),
 
   /**
    * Individual transport tokens (for factory registration)
    */
-  ConsoleTransport: Symbol.for('Logger.ConsoleTransport'),
+  ConsoleTransport: Symbol.for('stratal:logger:console:transport'),
 
   /**
    * Configured log level for filtering
    */
-  LogLevelOptions: Symbol.for('Logger.LogLevelOptions'),
+  LogLevelOptions: Symbol.for('stratal:logger:log:level:options'),
 } as const

--- a/packages/core/src/openapi/openapi.tokens.ts
+++ b/packages/core/src/openapi/openapi.tokens.ts
@@ -3,11 +3,11 @@
  */
 export const OPENAPI_TOKENS = {
   /** Static options provided via forRoot() */
-  Options: Symbol.for('OpenAPIModule.Options'),
+  Options: Symbol.for('stratal:openapi:options'),
 
   /** Request-scoped config service that supports runtime overrides */
-  ConfigService: Symbol.for('OpenAPIModule.ConfigService'),
+  ConfigService: Symbol.for('stratal:openapi:config:service'),
 
   /** OpenAPI service that generates specs and serves endpoints */
-  OpenAPIService: Symbol.for('OpenAPIModule.OpenAPIService'),
+  OpenAPIService: Symbol.for('stratal:openapi:service'),
 } as const

--- a/packages/core/src/queue/queue.tokens.ts
+++ b/packages/core/src/queue/queue.tokens.ts
@@ -1,7 +1,7 @@
 export const QUEUE_TOKENS = {
-  QueueProviderFactory: Symbol.for('QueueProviderFactory'),
-  QueueRegistry: Symbol.for('QueueRegistry'),
-  QueueModuleOptions: Symbol.for('QueueModuleOptions'),
+  QueueProviderFactory: Symbol.for('stratal:queue:provider:factory'),
+  QueueRegistry: Symbol.for('stratal:queue:registry'),
+  QueueModuleOptions: Symbol.for('stratal:queue:options'),
 } as const
 
 export type QueueToken = (typeof QUEUE_TOKENS)[keyof typeof QUEUE_TOKENS]

--- a/packages/core/src/router/router.tokens.ts
+++ b/packages/core/src/router/router.tokens.ts
@@ -6,5 +6,5 @@ export const ROUTER_TOKENS = {
    * Token for RouterContext (request-scoped)
    * Contains Hono context wrapper with helper methods
    */
-  RouterContext: Symbol.for('RouterContext'),
+  RouterContext: Symbol.for('stratal:router:context'),
 } as const

--- a/packages/core/src/storage/storage.tokens.ts
+++ b/packages/core/src/storage/storage.tokens.ts
@@ -3,7 +3,7 @@
  * Using Symbol-based tokens to avoid magic strings
  */
 export const STORAGE_TOKENS = {
-  Options: Symbol.for('StorageModuleOptions'),
-  StorageService: Symbol.for('StorageService'),
-  StorageManager: Symbol.for('StorageManager'),
+  Options: Symbol.for('stratal:storage:options'),
+  StorageService: Symbol.for('stratal:storage:service'),
+  StorageManager: Symbol.for('stratal:storage:manager'),
 } as const

--- a/packages/framework/src/auth/auth.tokens.ts
+++ b/packages/framework/src/auth/auth.tokens.ts
@@ -1,5 +1,5 @@
 /** Token for AuthService - core authentication service */
-export const AUTH_SERVICE = Symbol.for('Core.AuthService')
+export const AUTH_SERVICE = Symbol.for('stratal:auth:service')
 
 /** Token for Better Auth options configuration */
-export const AUTH_OPTIONS = Symbol.for('Core.AuthOptions')
+export const AUTH_OPTIONS = Symbol.for('stratal:auth:options')

--- a/packages/framework/src/database/database.tokens.ts
+++ b/packages/framework/src/database/database.tokens.ts
@@ -1,10 +1,10 @@
 export const DATABASE_TOKENS = {
-  Options: Symbol.for('DatabaseModuleOptions'),
-  Services: Symbol.for('DatabaseServices'),
+  Options: Symbol.for('stratal:database:options'),
+  Services: Symbol.for('stratal:database:services'),
 } as const
 
 import type { ConnectionName } from './types'
 
 export function connectionSymbol(name: ConnectionName): symbol {
-  return Symbol.for(`DatabaseConnection:${name}`)
+  return Symbol.for(`stratal:database:connection:${name}`)
 }

--- a/packages/framework/src/rbac/tokens.ts
+++ b/packages/framework/src/rbac/tokens.ts
@@ -3,7 +3,7 @@
  */
 export const RBAC_TOKENS = {
   /** Request-scoped Casbin service with auto context resolution */
-  CasbinService: Symbol.for('CasbinService'),
+  CasbinService: Symbol.for('stratal:rbac:casbin:service'),
   /** RBAC module options (model, policies, hierarchy) */
-  Options: Symbol.for('RbacModuleOptions'),
+  Options: Symbol.for('stratal:rbac:options'),
 } as const


### PR DESCRIPTION
## Summary
Standardizes all `Symbol.for()` DI tokens across core and framework packages to use a consistent `stratal:` namespace prefix (e.g., `Symbol.for('CacheService')` → `Symbol.for('stratal:cache:service')`). This prevents token collisions with user-defined symbols and establishes a clear naming convention.

## How to Test
- Run `yarn workspace stratal test` — all core tests pass (including updated `register-as` assertions)
- Run `yarn workspace @stratal/framework pretest && yarn workspace @stratal/framework test` — framework tests pass
- Verify no hardcoded old symbol names remain: `grep -r "Symbol.for(" packages/ --include="*.ts" | grep -v "stratal:"`

## Breaking Changes
- All DI token symbol values have changed (e.g., `Symbol.for('CacheService')` → `Symbol.for('stratal:cache:service')`). Any code using `Symbol.for()` with old token names to reference framework internals will break. Use the exported token constants (`DI_TOKENS`, `CACHE_TOKENS`, etc.) instead.
- `connectionSymbol()` now returns `Symbol.for('stratal:database:connection:<name>')` instead of `Symbol.for('DatabaseConnection:<name>')`.