### PR TITLE
feat(router): add HTTP method decorators for explicit route handling

### DIFF
--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -9,12 +9,13 @@ description: >-
   i18n, logging, guards, middleware, config, OpenAPIModule, ConfigModule, CacheModule,
   EmailModule, StorageModule, QueueModule, I18nModule, ApplicationError, StratalEnv,
   registerAs, StratalDurableObject, StratalWorkerEntrypoint, StratalWorkflow, runInScope,
-  stratal/workers, DurableObject, Workflow, WorkerEntrypoint, Service Binding, RPC.
+  stratal/workers, DurableObject, Workflow, WorkerEntrypoint, Service Binding, RPC,
+  @Get, @Post, @Put, @Patch, @Delete, @All, HttpRouteMetadata, RouteConfig.
 user-invocable: false
 license: MIT
 metadata:
   author: Temitayo Fadojutimi
-  version: "2.0"
+  version: "3.0"
 ---
 
 # Stratal Core Framework
@@ -80,9 +81,53 @@ export class UsersController implements IController {
 }
 ```
 
-**Method → HTTP mapping:** `index` → GET, `show` → GET /:id, `create` → POST (201), `update` → PUT /:id, `patch` → PATCH /:id, `destroy` → DELETE /:id.
+**Method → HTTP mapping (convention-based):** `index` → GET, `show` → GET /:id, `create` → POST (201), `update` → PUT /:id, `patch` → PATCH /:id, `destroy` → DELETE /:id.
 
 Use `await ctx.body<T>()` to get validated body — **not** `ctx.req.valid('json')`.
+
+### HTTP Method Decorators
+
+As an alternative to convention-based `@Route()`, use explicit HTTP method decorators for full control over method and path:
+
+```ts
+import { Controller, Get, Post, All } from 'stratal/router';
+
+@Controller('/api/v1/users', { tags: ['Users'] })
+export class UsersController implements IController {
+  constructor(@inject(UsersService) private usersService: UsersService) {}
+
+  @Get('/', { response: UsersListSchema })
+  async list(ctx: RouterContext) {
+    return ctx.json(await this.usersService.findAll());
+  }
+
+  @Post('/', { body: CreateUserSchema, response: UserSchema, statusCode: 201 })
+  async create(ctx: RouterContext) {
+    const data = await ctx.body<CreateUserInput>();
+    return ctx.json(await this.usersService.create(data), 201);
+  }
+
+  @Get('/:id', { params: z.object({ id: z.string().uuid() }), response: UserSchema })
+  async show(ctx: RouterContext) {
+    const { id } = ctx.params<{ id: string }>();
+    return ctx.json(await this.usersService.findById(id));
+  }
+
+  @All('/:path{.+}', { response: z.object({ message: z.string() }) })
+  async catchAll(ctx: RouterContext) {
+    return ctx.json({ message: 'Not found' }, 404);
+  }
+}
+```
+
+**Available decorators:** `@Get(path, config?)`, `@Post(path, config?)`, `@Put(path, config?)`, `@Patch(path, config?)`, `@Delete(path, config?)`, `@All(path, config?)`.
+
+**`RouteConfig` options:** `body`, `params`, `query`, `response` (required), `tags`, `security`, `description`, `summary`, `statusCode`, `hideFromDocs`.
+
+**Key rules:**
+- HTTP method decorators and `@Route()` **cannot be mixed** in the same controller — use one pattern or the other
+- Default status code is `200` for all methods; use `statusCode: 201` explicitly for POST create endpoints
+- `@All` routes are **automatically hidden** from OpenAPI docs (OpenAPI doesn't support catch-all HTTP methods)
 
 ## Dependency Injection
 
@@ -326,7 +371,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 |---|---|
 | `stratal` | `Stratal`, `Application`, `@Module`, `StratalEnv` |
 | `stratal/di` | `Container`, `DI_TOKENS`, `Scope`, `inject`, `Transient` |
-| `stratal/router` | `@Controller`, `@Route`, `RouterContext`, `UseGuards`, `IController` |
+| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouterContext`, `UseGuards`, `IController` |
 | `stratal/validation` | `z` (Zod), `ZodType`, validation utilities |
 | `stratal/errors` | `ApplicationError`, `ERROR_CODES`, built-in error classes |
 | `stratal/events` | `@Listener`, `@On`, `EventRegistry` |

--- a/.changeset/add-http-method-decorators.md
+++ b/.changeset/add-http-method-decorators.md
@@ -1,0 +1,16 @@
+---
+"stratal": patch
+---
+
+Add HTTP method decorators (`@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`) for explicit route handling as an alternative to convention-based `@Route()` routing
+
+### Details
+
+- **stratal**
+  - Add `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, and `@All` decorators that accept an explicit path and optional `RouteConfig`
+  - Routes decorated with `@All` are automatically hidden from OpenAPI documentation
+  - Enforce mutual exclusivity: a controller cannot mix `@Route()` with HTTP method decorators
+  - Add `statusCode` option to `RouteConfig` for explicit status code control in HTTP method decorators
+  - Add `HttpRouteMetadata` type and `'all'` to the `HttpMethod` union
+  - Remove `statusCode` from the `@Route()` decorator signature (status codes are auto-derived from method names in convention-based routing)
+  - Export new decorators and helpers (`getHttpRouteMetadata`, `getHttpDecoratedMethods`) from `stratal/router`

--- a/packages/core/src/router/constants.ts
+++ b/packages/core/src/router/constants.ts
@@ -17,6 +17,8 @@ export const ROUTE_METADATA_KEYS = {
   CONTROLLER_MIDDLEWARES: Symbol.for('stratal:controller:middlewares'),
   ROUTE_CONFIG: Symbol.for('stratal:route:config'),
   DECORATED_METHODS: Symbol.for('stratal:decorated:methods'),
+  HTTP_ROUTE_CONFIG: Symbol.for('stratal:http-route:config'),
+  HTTP_DECORATED_METHODS: Symbol.for('stratal:http-decorated:methods'),
   AUTH_GUARD: Symbol.for('stratal:auth:guard')
 } as const
 

--- a/packages/core/src/router/decorators/http-method.decorator.ts
+++ b/packages/core/src/router/decorators/http-method.decorator.ts
@@ -1,0 +1,135 @@
+import { z } from '../../i18n/validation'
+import { ROUTE_METADATA_KEYS } from '../constants'
+import type { HttpMethod, HttpRouteMetadata, RouteConfig } from '../types'
+
+/**
+ * Creates an HTTP method decorator factory for the given HTTP method.
+ *
+ * The returned decorator stores {@link HttpRouteMetadata} on the method and
+ * tracks the method name under {@link ROUTE_METADATA_KEYS.HTTP_DECORATED_METHODS}
+ * on the controller prototype so they can be discovered at registration time.
+ */
+function createHttpMethodDecorator(method: HttpMethod) {
+  return function (path: string, config?: RouteConfig) {
+    return function (
+      target: object,
+      propertyKey: string,
+      descriptor: PropertyDescriptor
+    ) {
+      const metadata: HttpRouteMetadata = {
+        method,
+        path,
+        config: config ?? { response: z.any() },
+      }
+
+      Reflect.defineMetadata(
+        ROUTE_METADATA_KEYS.HTTP_ROUTE_CONFIG,
+        metadata,
+        target,
+        propertyKey
+      )
+
+      // Track this method as HTTP-decorated on the prototype
+      const existing: string[] =
+        (Reflect.getOwnMetadata(ROUTE_METADATA_KEYS.HTTP_DECORATED_METHODS, target) as string[] | undefined) ?? []
+      existing.push(propertyKey)
+      Reflect.defineMetadata(ROUTE_METADATA_KEYS.HTTP_DECORATED_METHODS, existing, target)
+
+      return descriptor
+    }
+  }
+}
+
+/**
+ * Registers a GET route on the controller method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration (response schema, body, params, etc.)
+ *
+ * @example
+ * ```typescript
+ * @Controller('/api/v1/users')
+ * class UsersController {
+ *   @Get('/', { response: z.array(userSchema), summary: 'List users' })
+ *   async list(ctx: RouterContext) { ... }
+ *
+ *   @Get('/:id', { params: z.object({ id: z.string().uuid() }), response: userSchema })
+ *   async getUser(ctx: RouterContext) { ... }
+ * }
+ * ```
+ */
+export const Get = createHttpMethodDecorator('get')
+
+/**
+ * Registers a POST route on the controller method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration (response schema, body, params, etc.)
+ *
+ * @example
+ * ```typescript
+ * @Controller('/api/v1/users')
+ * class UsersController {
+ *   @Post('/', { body: createUserSchema, response: userSchema, statusCode: 201 })
+ *   async createUser(ctx: RouterContext) { ... }
+ * }
+ * ```
+ */
+export const Post = createHttpMethodDecorator('post')
+
+/**
+ * Registers a PUT route on the controller method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration
+ */
+export const Put = createHttpMethodDecorator('put')
+
+/**
+ * Registers a PATCH route on the controller method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration
+ */
+export const Patch = createHttpMethodDecorator('patch')
+
+/**
+ * Registers a DELETE route on the controller method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration
+ */
+export const Delete = createHttpMethodDecorator('delete')
+
+/**
+ * Registers an ALL (any HTTP method) route on the controller method.
+ * Routes using @All are automatically hidden from OpenAPI documentation
+ * since OpenAPI does not support a catch-all HTTP method.
+ *
+ * @param path - Route path relative to the controller base path
+ * @param config - Optional route configuration
+ */
+export const All = createHttpMethodDecorator('all')
+
+/**
+ * Get the HTTP route metadata from a controller method decorated with
+ * @Get, @Post, @Put, @Patch, @Delete, or @All.
+ *
+ * @param target - Controller prototype
+ * @param methodName - Name of the method
+ * @returns HTTP route metadata or undefined if not decorated
+ */
+export function getHttpRouteMetadata(target: object, methodName: string): HttpRouteMetadata | undefined {
+  return Reflect.getMetadata(ROUTE_METADATA_KEYS.HTTP_ROUTE_CONFIG, target, methodName) as HttpRouteMetadata | undefined
+}
+
+/**
+ * Get all methods decorated with HTTP method decorators from a controller class.
+ *
+ * @param ControllerClass - Controller class
+ * @returns Array of method names that have HTTP route metadata
+ */
+export function getHttpDecoratedMethods(ControllerClass: new (...args: unknown[]) => object): string[] {
+  const prototype = ControllerClass.prototype as object
+  return (Reflect.getOwnMetadata(ROUTE_METADATA_KEYS.HTTP_DECORATED_METHODS, prototype) as string[] | undefined) ?? []
+}

--- a/packages/core/src/router/decorators/index.ts
+++ b/packages/core/src/router/decorators/index.ts
@@ -1,6 +1,7 @@
 export {
   Controller, getControllerOptions, getControllerRoute
 } from './controller.decorator'
+export { All, Delete, Get, getHttpDecoratedMethods, getHttpRouteMetadata, Patch, Post, Put } from './http-method.decorator'
 export { getDecoratedMethods, getRouteConfig, Route } from './route.decorator'
 
 // Guards are now exported from core/guards module

--- a/packages/core/src/router/decorators/route.decorator.ts
+++ b/packages/core/src/router/decorators/route.decorator.ts
@@ -2,7 +2,10 @@ import { ROUTE_METADATA_KEYS } from '../constants'
 import type { RouteConfig } from '../types'
 
 /**
- * Decorator to add OpenAPI metadata to a controller method
+ * Decorator to add OpenAPI metadata to a controller method using convention-based routing.
+ *
+ * **Cannot be mixed with HTTP method decorators** (`@Get`, `@Post`, `@Put`, `@Patch`,
+ * `@Delete`, `@All`) in the same controller. Use one pattern or the other.
  *
  * Stores route configuration (schemas, response, tags, security) in metadata.
  * HTTP method, path, and success status code are auto-derived from the method name:
@@ -70,7 +73,7 @@ import type { RouteConfig } from '../types'
  * }
  * ```
  */
-export function Route(config: RouteConfig) {
+export function Route(config: Omit<RouteConfig, 'statusCode'>) {
   return function (
     target: object,
     propertyKey: string,

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -4,7 +4,7 @@
 // Core router types
 export type { IController } from './controller'
 export type { Middleware } from './middleware.interface'
-export type { ControllerOptions, RouteConfig, RouterEnv, RouteResponse, RouterVariables, SecurityScheme } from './types'
+export type { ControllerOptions, HttpRouteMetadata, RouteConfig, RouterEnv, RouteResponse, RouterVariables, SecurityScheme } from './types'
 
 // Router constants
 export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEMES } from './constants'
@@ -27,6 +27,7 @@ export { ROUTER_TOKENS } from './router.tokens'
 export {
   Controller, getControllerOptions, getControllerRoute
 } from './decorators/controller.decorator'
+export { All, Delete, Get, getHttpDecoratedMethods, getHttpRouteMetadata, Patch, Post, Put } from './decorators/http-method.decorator'
 export { getDecoratedMethods, getRouteConfig, Route } from './decorators/route.decorator'
 
 // Schemas

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -16,6 +16,8 @@ import {
   getControllerOptions,
   getControllerRoute,
   getDecoratedMethods,
+  getHttpDecoratedMethods,
+  getHttpRouteMetadata,
   getRouteConfig
 } from '../decorators'
 import {
@@ -111,11 +113,23 @@ export class RouteRegistrationService {
       return
     }
 
-    // Check for OpenAPI decorated methods
+    // Check for both decorator types
     const decoratedMethods = getDecoratedMethods(ControllerClass)
+    const httpDecoratedMethods = getHttpDecoratedMethods(ControllerClass)
 
-    if (decoratedMethods.length > 0) {
-      // Register OpenAPI routes
+    // Enforce mutual exclusivity: a controller cannot mix @Route() with HTTP method decorators
+    if (decoratedMethods.length > 0 && httpDecoratedMethods.length > 0) {
+      throw new ControllerRegistrationError(
+        ControllerClass.name,
+        'Cannot mix @Route() with HTTP method decorators (@Get, @Post, etc.) in the same controller. Use one pattern or the other.'
+      )
+    }
+
+    if (httpDecoratedMethods.length > 0) {
+      // Register explicit HTTP method routes (@Get, @Post, etc.)
+      this.registerHttpRoutes(app, ControllerClass, route, httpDecoratedMethods, controllerOpts)
+    } else if (decoratedMethods.length > 0) {
+      // Register OpenAPI routes (@Route with convention-based method names)
       this.registerOpenAPIRoutes(app, ControllerClass, route, decoratedMethods, controllerOpts)
     } else {
       // Fallback to traditional RESTful method registration (no OpenAPI)
@@ -265,6 +279,104 @@ export class RouteRegistrationService {
   }
 
   /**
+   * Register routes using HTTP method decorators (@Get, @Post, etc.)
+   * These use explicit method + path instead of convention-based derivation
+   */
+  private registerHttpRoutes(
+    app: OpenAPIHono<RouterEnv>,
+    ControllerClass: Constructor<IController>,
+    basePath: string,
+    httpDecoratedMethods: string[],
+    controllerOpts: ControllerOptions | undefined
+  ): void {
+    const className = ControllerClass.name
+    const prototype = ControllerClass.prototype as IController
+
+    const controllerHidden = controllerOpts?.hideFromDocs ?? false
+    const controllerGuards = getControllerGuards(ControllerClass)?.guards ?? []
+
+    for (const methodName of httpDecoratedMethods) {
+      const httpMeta = getHttpRouteMetadata(prototype, methodName)
+      if (!httpMeta) continue
+
+      const fullPath = this.joinPaths(basePath, httpMeta.path)
+      const routeConfig = httpMeta.config
+      const hideFromDocs = routeConfig.hideFromDocs ?? controllerHidden
+
+      // @All routes or hidden routes are registered without OpenAPI
+      if (httpMeta.method === 'all' || hideFromDocs) {
+        this.logger.info(`Registering route (no OpenAPI)`, {
+          controller: className,
+          method: httpMeta.method.toUpperCase(),
+          path: fullPath,
+          methodName,
+        })
+
+        this.registerRouteWithoutOpenAPI(app, ControllerClass, methodName, {
+          method: httpMeta.method,
+          path: fullPath,
+        })
+        continue
+      }
+
+      // Collect method-level guards
+      const methodGuards = getMethodGuards(prototype, methodName)?.guards ?? []
+      const allGuards: Guard[] = [...controllerGuards, ...methodGuards]
+
+      if (allGuards.length > 0) {
+        this.logger.info(`Route guards`, {
+          controller: className,
+          method: httpMeta.method.toUpperCase(),
+          path: fullPath,
+          methodName,
+          guardCount: allGuards.length,
+        })
+      }
+
+      // Build and register OpenAPI route
+      const metadata = this.mergeMetadata(controllerOpts, routeConfig, ControllerClass, methodName)
+      const statusCode = routeConfig.statusCode ?? 200
+      const openApiRoute = this.buildOpenAPIRoute(
+        httpMeta.method,
+        fullPath,
+        routeConfig,
+        metadata,
+        allGuards,
+        undefined,
+        statusCode
+      )
+
+      this.logger.info(`Registering OpenAPI route`, {
+        controller: className,
+        method: httpMeta.method.toUpperCase(),
+        path: fullPath,
+        methodName,
+        tags: metadata.tags,
+      })
+
+      app.openapi(openApiRoute, async (c) => {
+        const ctx = new RouterContext(c)
+        const requestContainer = ctx.getContainer()
+        const controller = requestContainer.resolve<IController>(ControllerClass)
+        const method = controller[methodName as keyof IController]
+        if (typeof method === 'function') {
+          const injectedArgs = this.resolveMethodInjections(prototype, methodName, requestContainer)
+          return await (method as (...args: unknown[]) => Promise<Response>).call(controller, ctx, ...injectedArgs)
+        }
+        throw new ControllerMethodNotFoundError(methodName, className)
+      })
+    }
+  }
+
+  /**
+   * Join a base path and a route path, normalizing slashes
+   */
+  private joinPaths(basePath: string, routePath: string): string {
+    if (routePath === '/') return basePath
+    return basePath + routePath
+  }
+
+  /**
    * Register route without OpenAPI metadata (for hidden routes)
    * Route is functional but won't appear in documentation
    */
@@ -307,6 +419,9 @@ export class RouteRegistrationService {
       case 'delete':
         app.delete(derived.path, handler)
         break
+      case 'all':
+        app.all(derived.path, handler)
+        break
       default:
         // For head, options, trace, or any other method, use all()
         app.all(derived.path, handler)
@@ -348,12 +463,12 @@ export class RouteRegistrationService {
    * Auto-derive HTTP method and path from controller method name
    * Uses HTTP_METHODS constant for RESTful convention mapping
    */
-  private deriveHttpMethodAndPath(methodName: string, basePath: string): { method: HttpMethod; path: string } | null {
+  private deriveHttpMethodAndPath(methodName: string, basePath: string): { method: Exclude<HttpMethod, 'all'>; path: string } | null {
     if (!(methodName in HTTP_METHODS)) return null
     const mapping = HTTP_METHODS[methodName as keyof typeof HTTP_METHODS]
 
     return {
-      method: mapping.method as HttpMethod,
+      method: mapping.method as Exclude<HttpMethod, 'all'>,
       path: basePath + mapping.path,
     }
   }
@@ -410,12 +525,13 @@ export class RouteRegistrationService {
    * Execution order: Global middlewares → Guards → Handler
    */
   private buildOpenAPIRoute(
-    method: HttpMethod,
+    method: Exclude<HttpMethod, 'all'>,
     path: string,
     routeConfig: RouteConfig,
     metadata: { tags: string[]; security: Record<string, string[]>[] },
     guards: Guard[],
-    methodName?: string
+    methodName?: string,
+    statusCodeOverride?: number
   ): OpenAPIRouteConfig {
     try {
       const route: Partial<OpenAPIRouteConfig> = {
@@ -460,9 +576,10 @@ export class RouteRegistrationService {
         }
       }
 
-      // Derive success status code from method name
-
-      const successStatus = (methodName && METHOD_STATUS_CODES[methodName as keyof typeof METHOD_STATUS_CODES]) ?? 200
+      // Derive success status code from method name or use override
+      const successStatus = statusCodeOverride
+        ?? (methodName && METHOD_STATUS_CODES[methodName as keyof typeof METHOD_STATUS_CODES])
+        ?? 200
 
       // Build responses object with auto-derived status
       const responses: NonNullable<OpenAPIRouteConfig['responses']> = {}

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -42,7 +42,7 @@ export type MethodName = keyof typeof HTTP_METHODS
 /**
  * HTTP method type from OpenAPI spec
  */
-export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace'
+export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace' | 'all'
 
 /**
  * Security scheme record for OpenAPI security array format
@@ -119,6 +119,23 @@ export interface RouteConfig {
    * Useful for internal-only endpoints, debug routes, or work-in-progress features
    */
   hideFromDocs?: boolean
+
+  /**
+   * HTTP success status code for the response
+   * Used by HTTP method decorators (@Get, @Post, etc.) to set the success status
+   * For @Route() decorator, status code is auto-derived from method name
+   */
+  statusCode?: number
+}
+
+/**
+ * Metadata stored by HTTP method decorators (@Get, @Post, etc.)
+ * Contains the explicit HTTP method, path, and route configuration
+ */
+export interface HttpRouteMetadata {
+  method: HttpMethod
+  path: string
+  config: RouteConfig
 }
 
 /**

--- a/packages/core/test/fixtures/http-method.controller.ts
+++ b/packages/core/test/fixtures/http-method.controller.ts
@@ -1,0 +1,114 @@
+import { z } from '../../src/i18n/validation'
+import { Module } from '../../src/module/module.decorator'
+import { Controller } from '../../src/router/decorators/controller.decorator'
+import { All, Delete, Get, Patch, Post, Put } from '../../src/router/decorators/http-method.decorator'
+import { Route } from '../../src/router/decorators/route.decorator'
+import type { RouterContext } from '../../src/router/router-context'
+
+@Controller('/api/http-methods', { tags: ['HttpMethods'] })
+export class HttpMethodController {
+  @Get('/', {
+    response: z.object({ items: z.array(z.string()) }),
+    summary: 'List items',
+  })
+  listItems(ctx: RouterContext) {
+    return ctx.json({ items: ['a', 'b'] })
+  }
+
+  // Static path must come before parametric /:id to avoid conflicts
+  @Get('/search', {
+    query: z.object({ q: z.string().min(1), limit: z.string().optional() }),
+    response: z.object({ results: z.array(z.string()), query: z.string() }),
+  })
+  searchItems(ctx: RouterContext) {
+    const query = ctx.query<{ q: string; limit?: string }>()
+    return ctx.json({ results: ['result1'], query: query.q })
+  }
+
+  @Get('/:id', {
+    params: z.object({ id: z.string() }),
+    response: z.object({ id: z.string() }),
+  })
+  getItem(ctx: RouterContext) {
+    const id = ctx.param('id')
+    return ctx.json({ id })
+  }
+
+  @Post('/', {
+    body: z.object({ name: z.string().min(1) }),
+    response: z.object({ id: z.string(), name: z.string() }),
+    statusCode: 201,
+  })
+  async createItem(ctx: RouterContext) {
+    const body = await ctx.body<{ name: string }>()
+    return ctx.json({ id: '1', name: body.name }, 201)
+  }
+
+  @Put('/:id', {
+    params: z.object({ id: z.string() }),
+    body: z.object({ name: z.string().min(1) }),
+    response: z.object({ id: z.string(), name: z.string() }),
+  })
+  async updateItem(ctx: RouterContext) {
+    const id = ctx.param('id')
+    const body = await ctx.body<{ name: string }>()
+    return ctx.json({ id, name: body.name })
+  }
+
+  @Patch('/:id', {
+    params: z.object({ id: z.string() }),
+    body: z.object({ name: z.string().optional() }),
+    response: z.object({ id: z.string(), name: z.string() }),
+  })
+  async patchItem(ctx: RouterContext) {
+    const id = ctx.param('id')
+    const body = await ctx.body<{ name?: string }>()
+    return ctx.json({ id, name: body.name ?? 'default' })
+  }
+
+  @Delete('/:id', {
+    params: z.object({ id: z.string() }),
+    response: z.object({ deleted: z.boolean() }),
+  })
+  deleteItem(ctx: RouterContext) {
+    return ctx.json({ deleted: true })
+  }
+
+  @Post('/:id/avatar', {
+    params: z.object({ id: z.string() }),
+    body: z.object({ url: z.string().url() }),
+    response: z.object({ id: z.string(), avatarUrl: z.string() }),
+    statusCode: 201,
+  })
+  async uploadAvatar(ctx: RouterContext) {
+    const id = ctx.param('id')
+    const body = await ctx.body<{ url: string }>()
+    return ctx.json({ id, avatarUrl: body.url }, 201)
+  }
+}
+
+@Controller('/api/catch-all')
+export class AllMethodController {
+  @All('/:path{.+}')
+  handle(ctx: RouterContext) {
+    return ctx.json({ method: ctx.c.req.method, path: ctx.c.req.path })
+  }
+}
+
+@Controller('/api/mixed')
+export class MixedController {
+  @Route({ response: z.object({ ok: z.boolean() }) })
+  index(ctx: RouterContext) {
+    return ctx.json({ ok: true })
+  }
+
+  @Get('/custom', { response: z.object({ ok: z.boolean() }) })
+  custom(ctx: RouterContext) {
+    return ctx.json({ ok: true })
+  }
+}
+
+@Module({
+  controllers: [HttpMethodController, AllMethodController],
+})
+export class HttpMethodAppModule {}

--- a/packages/core/test/integration/http-method-decorators.spec.ts
+++ b/packages/core/test/integration/http-method-decorators.spec.ts
@@ -1,0 +1,215 @@
+import { Test, type TestingModule } from '@stratal/testing'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Module } from '../../src/module/module.decorator'
+import {
+  HttpMethodAppModule,
+  MixedController,
+} from '../fixtures/http-method.controller'
+
+describe('HTTP Method Decorators', () => {
+  let module: TestingModule
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [HttpMethodAppModule],
+    }).compile()
+  })
+
+  afterAll(async () => {
+    await module.close()
+  })
+
+  describe('@Get', () => {
+    it('GET / returns list', async () => {
+      const response = await module.http
+        .get('/api/http-methods')
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPathMatches(
+        'items',
+        (items) => Array.isArray(items) && items.length === 2 && items[0] === 'a' && items[1] === 'b',
+      )
+    })
+
+    it('GET /:id returns item by id', async () => {
+      const response = await module.http
+        .get('/api/http-methods/abc')
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('id', 'abc')
+    })
+  })
+
+  describe('@Post', () => {
+    it('POST / creates item with 201 status code', async () => {
+      const response = await module.http
+        .post('/api/http-methods')
+        .withBody({ name: 'test-item' })
+        .send()
+
+      response.assertCreated()
+      await response.assertJsonPath('id', '1')
+      await response.assertJsonPath('name', 'test-item')
+    })
+
+    it('POST / validates request body (missing required field)', async () => {
+      const response = await module.http
+        .post('/api/http-methods')
+        .withBody({})
+        .send()
+
+      response.assertBadRequest()
+    })
+
+    it('POST / validates request body (empty string fails min(1))', async () => {
+      const response = await module.http
+        .post('/api/http-methods')
+        .withBody({ name: '' })
+        .send()
+
+      response.assertBadRequest()
+    })
+
+    it('POST /:id/avatar handles custom nested path', async () => {
+      const response = await module.http
+        .post('/api/http-methods/42/avatar')
+        .withBody({ url: 'https://example.com/avatar.png' })
+        .send()
+
+      response.assertCreated()
+      await response.assertJsonPath('id', '42')
+      await response.assertJsonPath('avatarUrl', 'https://example.com/avatar.png')
+    })
+  })
+
+  describe('@Put', () => {
+    it('PUT /:id updates item', async () => {
+      const response = await module.http
+        .put('/api/http-methods/99')
+        .withBody({ name: 'updated' })
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('id', '99')
+      await response.assertJsonPath('name', 'updated')
+    })
+  })
+
+  describe('@Patch', () => {
+    it('PATCH /:id patches item', async () => {
+      const response = await module.http
+        .patch('/api/http-methods/55')
+        .withBody({ name: 'patched' })
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('id', '55')
+      await response.assertJsonPath('name', 'patched')
+    })
+
+    it('PATCH /:id with empty body uses default', async () => {
+      const response = await module.http
+        .patch('/api/http-methods/55')
+        .withBody({})
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('name', 'default')
+    })
+  })
+
+  describe('@Delete', () => {
+    it('DELETE /:id deletes item', async () => {
+      const response = await module.http
+        .delete('/api/http-methods/77')
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('deleted', true)
+    })
+  })
+
+  describe('@Get with query params', () => {
+    it('GET /search validates and passes query params', async () => {
+      const response = await module.http
+        .get('/api/http-methods/search?q=hello')
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('query', 'hello')
+    })
+
+    it('GET /search rejects missing required query param', async () => {
+      const response = await module.http
+        .get('/api/http-methods/search')
+        .send()
+
+      response.assertBadRequest()
+    })
+  })
+
+  describe('@All', () => {
+    it('matches GET requests', async () => {
+      const response = await module.http
+        .get('/api/catch-all/some/path')
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('method', 'GET')
+    })
+
+    it('matches POST requests', async () => {
+      const response = await module.http
+        .post('/api/catch-all/another/path')
+        .withBody({})
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('method', 'POST')
+    })
+
+    it('matches PUT requests', async () => {
+      const response = await module.http
+        .put('/api/catch-all/yet/another')
+        .withBody({})
+        .send()
+
+      response.assertOk()
+      await response.assertJsonPath('method', 'PUT')
+    })
+  })
+
+  describe('Controller options', () => {
+    it('inherits tags from @Controller', async () => {
+      const response = await module.http
+        .get('/api/http-methods')
+        .send()
+
+      response.assertOk()
+    })
+  })
+
+  describe('Mutual exclusivity', () => {
+    it('throws ControllerRegistrationError when mixing @Route and HTTP method decorators', async () => {
+      @Module({
+        controllers: [MixedController],
+      })
+      class MixedAppModule {}
+
+      await expect(
+        Test.createTestingModule({
+          imports: [MixedAppModule],
+        }).compile()
+      ).rejects.toMatchObject({
+        name: 'ControllerRegistrationError',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        metadata: expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          reason: expect.stringContaining('Cannot mix @Route() with HTTP method decorators'),
+        }),
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, and `@All` HTTP method decorators as an alternative to convention-based `@Route()` routing, giving controllers explicit control over HTTP method and path. Enforces mutual exclusivity — a controller must use one pattern or the other.

## How to Test
- Run `yarn workspace stratal test test/integration/http-method-decorators.spec.ts`
- Verify all 6 decorator types register routes correctly with expected status codes
- Confirm `@All` routes are hidden from OpenAPI docs
- Confirm mixing `@Route()` and HTTP method decorators throws `ControllerRegistrationError`

## Breaking Changes
- `HttpMethod` type now includes `'all'`
