### PR TITLE
feat(core): add URI-based API versioning support

### DIFF
--- a/.agents/skills/stratal-incremental-adoption/SKILL.md
+++ b/.agents/skills/stratal-incremental-adoption/SKILL.md
@@ -83,6 +83,11 @@ app.route('/api/v2', stratalHono)
 app.get('/api/v1/reports', (c) => c.json({ reports: [] }))
 app.post('/api/v1/webhooks', (c) => c.json({ received: true }))
 
+// TIP: Instead of manually embedding version prefixes in app.route(),
+// you can use Stratal's built-in versioning (see stratal skill):
+//   new Stratal({ module: AppModule, versioning: { prefix: 'v', defaultVersion: '2' } })
+// Then mount at /api and let versioning handle the /v2 prefix automatically.
+
 export default {
   fetch: app.fetch,
   async queue(batch: MessageBatch) {

--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   EmailModule, StorageModule, QueueModule, I18nModule, ApplicationError, StratalEnv,
   registerAs, StratalDurableObject, StratalWorkerEntrypoint, StratalWorkflow, runInScope,
   stratal/workers, DurableObject, Workflow, WorkerEntrypoint, Service Binding, RPC,
-  @Get, @Post, @Put, @Patch, @Delete, @All, HttpRouteMetadata, RouteConfig.
+  @Get, @Post, @Put, @Patch, @Delete, @All, HttpRouteMetadata, RouteConfig,
+  versioning, VERSION_NEUTRAL, VersioningOptions, defaultVersion, version prefix, API versioning.
 user-invocable: false
 license: MIT
 metadata:
@@ -40,7 +41,14 @@ Docs: [Installation](https://stratal.dev/getting-started/installation) · [Your 
 import { Stratal } from 'stratal';
 import { AppModule } from './app.module';
 
+// Without versioning
 const app = new Stratal({ module: AppModule });
+
+// With URI-based API versioning
+const app = new Stratal({
+  module: AppModule,
+  versioning: { prefix: 'v', defaultVersion: '1' },
+});
 
 export default app;
 ```
@@ -128,6 +136,52 @@ export class UsersController implements IController {
 - HTTP method decorators and `@Route()` **cannot be mixed** in the same controller — use one pattern or the other
 - Default status code is `200` for all methods; use `statusCode: 201` explicitly for POST create endpoints
 - `@All` routes are **automatically hidden** from OpenAPI docs (OpenAPI doesn't support catch-all HTTP methods)
+
+## API Versioning
+
+Docs: [API Versioning](https://stratal.dev/core-concepts/versioning/)
+
+Stratal supports URI-based API versioning. Enable it via `Stratal` config:
+
+```ts
+import { Stratal } from 'stratal';
+
+const app = new Stratal({
+  module: AppModule,
+  versioning: { prefix: 'v', defaultVersion: '1' },
+});
+```
+
+**Controller-level version:**
+
+```ts
+import { Controller, VERSION_NEUTRAL } from 'stratal/router';
+
+// Single version — routes served at /v1/users
+@Controller('/users', { version: '1' })
+export class UsersV1Controller implements IController { /* ... */ }
+
+// Multiple versions — routes served at both /v1/users and /v2/users
+@Controller('/users', { version: ['1', '2'] })
+export class UsersController implements IController { /* ... */ }
+
+// Version-neutral — routes served at /health (no version prefix)
+@Controller('/health', { version: VERSION_NEUTRAL })
+export class HealthController implements IController { /* ... */ }
+```
+
+**`defaultVersion` behavior:** When `defaultVersion` is set (e.g., `'1'`), controllers without an explicit `version` option are automatically assigned that version. Controllers with `VERSION_NEUTRAL` are not affected — they always remain unversioned.
+
+**Middleware version targeting:**
+
+```ts
+export class AppModule implements MiddlewareConfigurable {
+  configure(consumer: MiddlewareConsumer) {
+    // Target middleware to a specific API version
+    consumer.apply(V1DeprecationMiddleware).forRoutes({ path: '/users', version: '1' });
+  }
+}
+```
 
 ## Dependency Injection
 
@@ -371,7 +425,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 |---|---|
 | `stratal` | `Stratal`, `Application`, `@Module`, `StratalEnv` |
 | `stratal/di` | `Container`, `DI_TOKENS`, `Scope`, `inject`, `Transient` |
-| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouterContext`, `UseGuards`, `IController` |
+| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouterContext`, `UseGuards`, `IController`, `VERSION_NEUTRAL`, `VersioningOptions` |
 | `stratal/validation` | `z` (Zod), `ZodType`, validation utilities |
 | `stratal/errors` | `ApplicationError`, `ERROR_CODES`, built-in error classes |
 | `stratal/events` | `@Listener`, `@On`, `EventRegistry` |
@@ -400,4 +454,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 - **Do** export the `Stratal` instance as the default export (required for the static singleton used by worker classes)
 - **Do** use `runInScope` for each method/workflow step that needs DI — each call gets a fresh request-scoped container
 - **Don't** cache container references across `runInScope` calls — the container is only valid within the callback
+- **Do** use separate controllers for different API versions when behavior diverges
+- **Do** use `VERSION_NEUTRAL` for version-agnostic endpoints (health checks, OpenAPI docs, etc.)
+- **Don't** mix versioned and unversioned controllers for the same path without `VERSION_NEUTRAL`
 - **Don't** disable `emitDecoratorMetadata` in tsconfig

--- a/.changeset/add-uri-based-api-versioning.md
+++ b/.changeset/add-uri-based-api-versioning.md
@@ -1,0 +1,18 @@
+---
+"stratal": patch
+---
+
+Add URI-based API versioning support with configurable version prefix and default version
+
+### Details
+
+- **stratal**
+  - Add `versioning` option to `ApplicationConfig` to enable URI-based versioning (e.g., `/v1/users`, `/v2/users`)
+  - Add `version` option to `ControllerOptions` for per-controller version assignment (single, array, or `VERSION_NEUTRAL`)
+  - Add `VERSION_NEUTRAL` sentinel symbol to opt controllers out of versioning even when a `defaultVersion` is set
+  - Add `VersioningOptions` type with `prefix` (default `'v'`) and `defaultVersion` fields
+  - Add `getControllerVersion()` helper exported from `stratal/router`
+  - Extend `RouteRegistrationService` to resolve versioned paths for all route registration patterns (wildcard, OpenAPI, HTTP method, RESTful)
+  - Extend `MiddlewareConfigurationService` to resolve versioned `RouteInfo` targets with `version` field
+  - Add `version` field to `RouteInfo` middleware type for targeting versioned middleware routes
+  - Export `VersioningOptions` and `VERSION_NEUTRAL` from `stratal/router`

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -20,6 +20,7 @@ import { type QueueManager } from './queue/queue-manager'
 import { QueueModule } from './queue/queue.module'
 import { type IController, type RouterContext } from './router'
 import { HonoApp } from './router/hono-app'
+import type { VersioningOptions } from './router/types'
 import type { Constructor } from './types'
 
 export interface ApplicationConfig {
@@ -30,6 +31,11 @@ export interface ApplicationConfig {
     level?: LogLevel
     formatter?: 'json' | 'pretty'
   }
+  /**
+   * API versioning configuration.
+   * When provided, enables URI-based versioning for controllers.
+   */
+  versioning?: VersioningOptions
 }
 
 export interface ApplicationOptions extends ApplicationConfig {
@@ -142,7 +148,7 @@ export class Application {
     this.honoApp = new HonoApp(this._container, logger)
     const middlewareConfigs = this.moduleRegistry.getAllMiddlewareConfigs()
     const controllers = this.moduleRegistry.getAllControllers() as Constructor<IController>[]
-    this.honoApp.configure(middlewareConfigs, controllers)
+    this.honoApp.configure(middlewareConfigs, controllers, this.appConfig.versioning)
 
     // Phase 6: Configure queues, cron, events
     this.registerQueueConsumers()

--- a/packages/core/src/middleware/middleware-configuration.service.ts
+++ b/packages/core/src/middleware/middleware-configuration.service.ts
@@ -6,7 +6,7 @@ import type { IController } from '../router/controller'
 import { getControllerRoute } from '../router/decorators/controller.decorator'
 import type { Middleware } from '../router/middleware.interface'
 import { RouterContext } from '../router/router-context'
-import type { HttpMethod, RouterEnv } from '../router/types'
+import type { HttpMethod, RouterEnv, VersioningOptions } from '../router/types'
 import type { Constructor } from '../types'
 import type { MiddlewareConfigEntry, RouteInfo } from './types'
 
@@ -17,7 +17,10 @@ import type { MiddlewareConfigEntry, RouteInfo } from './types'
  * appropriate middleware handlers with route matching.
  */
 export class MiddlewareConfigurationService {
-  constructor(private readonly logger: LoggerService) { }
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly versioningOptions: VersioningOptions | null = null,
+  ) { }
 
   /**
    * Apply middleware configurations to the Hono app
@@ -90,12 +93,37 @@ export class MiddlewareConfigurationService {
           this.logger.warn('Controller has no route metadata', { controller: target.name })
         }
       } else {
-        // RouteInfo object - use directly
-        patterns.push(target)
+        // RouteInfo object - resolve version if present
+        const resolved = this.resolveVersionedRouteInfo(target)
+        patterns.push(...resolved)
       }
     }
 
     return patterns
+  }
+
+  /**
+   * Resolve a RouteInfo with version into versioned path(s).
+   * If versioning is disabled or no version is specified, returns the RouteInfo as-is.
+   */
+  private resolveVersionedRouteInfo(routeInfo: RouteInfo): RouteInfo[] {
+    if (!this.versioningOptions || !routeInfo.version) {
+      return [routeInfo]
+    }
+
+    const prefix = this.versioningOptions.prefix ?? 'v'
+    const versions = Array.isArray(routeInfo.version) ? routeInfo.version : [routeInfo.version]
+    const results: RouteInfo[] = []
+
+    for (const v of versions) {
+      const versionedPath = `/${prefix}${v}${routeInfo.path}`
+      // Add exact path match
+      results.push({ path: versionedPath, method: routeInfo.method })
+      // Add wildcard match for sub-paths
+      results.push({ path: `${versionedPath}/*`, method: routeInfo.method })
+    }
+
+    return results
   }
 
   /**

--- a/packages/core/src/middleware/middleware-configuration.service.ts
+++ b/packages/core/src/middleware/middleware-configuration.service.ts
@@ -94,8 +94,13 @@ export class MiddlewareConfigurationService {
         }
       } else {
         // RouteInfo object - resolve version if present
-        const resolved = this.resolveVersionedRouteInfo(target)
-        patterns.push(...resolved)
+        if (!this.versioningOptions || !target.version) {
+          // Fast path: no versioning or no version on target — push directly
+          patterns.push(target)
+        } else {
+          const resolved = this.resolveVersionedRouteInfo(target)
+          patterns.push(...resolved)
+        }
       }
     }
 

--- a/packages/core/src/middleware/types.ts
+++ b/packages/core/src/middleware/types.ts
@@ -11,6 +11,8 @@ export interface RouteInfo {
   path: string
   /** HTTP method(s) to match. If omitted, matches all methods */
   method?: HttpMethod | HttpMethod[]
+  /** API version(s) to target. When versioning is enabled, resolves to versioned path. */
+  version?: string | string[]
 }
 
 /**

--- a/packages/core/src/router/__tests__/versioning.spec.ts
+++ b/packages/core/src/router/__tests__/versioning.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { createMock } from '@stratal/testing/mocks'
+import type { LoggerService } from '../../logger/services/logger.service'
+import { RouteRegistrationService } from '../services/route-registration.service'
+import { VERSION_NEUTRAL } from '../constants'
+import type { ControllerOptions, VersioningOptions } from '../types'
+import { MiddlewareConfigurationService } from '../../middleware/middleware-configuration.service'
+
+const mockLogger = createMock<LoggerService>()
+
+interface RouteRegistrationServicePrivate {
+  resolveVersionedPaths(basePath: string, controllerOpts?: ControllerOptions): string[]
+}
+
+interface MiddlewareConfigServicePrivate {
+  resolveVersionedRouteInfo(routeInfo: { path: string; method?: string; version?: string | string[] }): { path: string; method?: string }[]
+}
+
+describe('Versioning', () => {
+  describe('RouteRegistrationService.resolveVersionedPaths()', () => {
+    const createService = (versioning: VersioningOptions | null = null) => {
+      const service = new RouteRegistrationService(mockLogger as unknown as LoggerService, versioning)
+      return service as unknown as RouteRegistrationServicePrivate
+    }
+
+    describe('versioning disabled (no config)', () => {
+      it('should return base path when no versioning config', () => {
+        const service = createService(null)
+        expect(service.resolveVersionedPaths('/users')).toEqual(['/users'])
+      })
+
+      it('should ignore version in controller options when versioning disabled', () => {
+        const service = createService(null)
+        expect(service.resolveVersionedPaths('/users', { version: '1' })).toEqual(['/users'])
+      })
+    })
+
+    describe('explicit version on controller', () => {
+      it('should prefix with version using default prefix "v"', () => {
+        const service = createService({})
+        expect(service.resolveVersionedPaths('/users', { version: '1' })).toEqual(['/v1/users'])
+      })
+
+      it('should support multi-version controller', () => {
+        const service = createService({})
+        const result = service.resolveVersionedPaths('/users', { version: ['1', '2'] })
+        expect(result).toEqual(['/v1/users', '/v2/users'])
+      })
+
+      it('should use custom prefix', () => {
+        const service = createService({ prefix: 'api/v' })
+        expect(service.resolveVersionedPaths('/users', { version: '1' })).toEqual(['/api/v1/users'])
+      })
+    })
+
+    describe('VERSION_NEUTRAL', () => {
+      it('should return base path without prefix', () => {
+        const service = createService({})
+        expect(service.resolveVersionedPaths('/health', { version: VERSION_NEUTRAL })).toEqual(['/health'])
+      })
+
+      it('should ignore defaultVersion when VERSION_NEUTRAL', () => {
+        const service = createService({ defaultVersion: '1' })
+        expect(service.resolveVersionedPaths('/health', { version: VERSION_NEUTRAL })).toEqual(['/health'])
+      })
+    })
+
+    describe('defaultVersion', () => {
+      it('should apply defaultVersion to controllers without explicit version', () => {
+        const service = createService({ defaultVersion: '1' })
+        expect(service.resolveVersionedPaths('/status')).toEqual(['/v1/status'])
+      })
+
+      it('should apply array defaultVersion', () => {
+        const service = createService({ defaultVersion: ['1', '2'] })
+        expect(service.resolveVersionedPaths('/status')).toEqual(['/v1/status', '/v2/status'])
+      })
+
+      it('should not apply defaultVersion when controller has explicit version', () => {
+        const service = createService({ defaultVersion: '1' })
+        expect(service.resolveVersionedPaths('/users', { version: '2' })).toEqual(['/v2/users'])
+      })
+
+      it('should not apply defaultVersion to VERSION_NEUTRAL controllers', () => {
+        const service = createService({ defaultVersion: '1' })
+        expect(service.resolveVersionedPaths('/health', { version: VERSION_NEUTRAL })).toEqual(['/health'])
+      })
+    })
+
+    describe('no version and no defaultVersion', () => {
+      it('should return base path unchanged', () => {
+        const service = createService({})
+        expect(service.resolveVersionedPaths('/status')).toEqual(['/status'])
+      })
+    })
+
+    describe('custom prefix', () => {
+      it('should use custom prefix for versioned paths', () => {
+        const service = createService({ prefix: 'api/v' })
+        expect(service.resolveVersionedPaths('/users', { version: '1' })).toEqual(['/api/v1/users'])
+      })
+
+      it('should use custom prefix with defaultVersion', () => {
+        const service = createService({ prefix: 'api/v', defaultVersion: '2' })
+        expect(service.resolveVersionedPaths('/users')).toEqual(['/api/v2/users'])
+      })
+    })
+  })
+
+  describe('MiddlewareConfigurationService.resolveVersionedRouteInfo()', () => {
+    const createService = (versioning: VersioningOptions | null = null) => {
+      const service = new MiddlewareConfigurationService(mockLogger as unknown as LoggerService, versioning)
+      return service as unknown as MiddlewareConfigServicePrivate
+    }
+
+    it('should return RouteInfo as-is when versioning disabled', () => {
+      const service = createService(null)
+      const result = service.resolveVersionedRouteInfo({ path: '/users', version: '1' })
+      expect(result).toEqual([{ path: '/users', version: '1' }])
+    })
+
+    it('should return RouteInfo as-is when no version specified', () => {
+      const service = createService({})
+      const result = service.resolveVersionedRouteInfo({ path: '/users' })
+      expect(result).toEqual([{ path: '/users' }])
+    })
+
+    it('should resolve version to versioned paths', () => {
+      const service = createService({})
+      const result = service.resolveVersionedRouteInfo({ path: '/users', version: '1' })
+      expect(result).toEqual([
+        { path: '/v1/users', method: undefined },
+        { path: '/v1/users/*', method: undefined },
+      ])
+    })
+
+    it('should resolve multiple versions', () => {
+      const service = createService({})
+      const result = service.resolveVersionedRouteInfo({ path: '/users', version: ['1', '2'] })
+      expect(result).toEqual([
+        { path: '/v1/users', method: undefined },
+        { path: '/v1/users/*', method: undefined },
+        { path: '/v2/users', method: undefined },
+        { path: '/v2/users/*', method: undefined },
+      ])
+    })
+
+    it('should preserve HTTP method in resolved routes', () => {
+      const service = createService({})
+      const result = service.resolveVersionedRouteInfo({ path: '/users', version: '1', method: 'get' })
+      expect(result).toEqual([
+        { path: '/v1/users', method: 'get' },
+        { path: '/v1/users/*', method: 'get' },
+      ])
+    })
+
+    it('should use custom prefix', () => {
+      const service = createService({ prefix: 'api/v' })
+      const result = service.resolveVersionedRouteInfo({ path: '/users', version: '1' })
+      expect(result).toEqual([
+        { path: '/api/v1/users', method: undefined },
+        { path: '/api/v1/users/*', method: undefined },
+      ])
+    })
+  })
+})

--- a/packages/core/src/router/constants.ts
+++ b/packages/core/src/router/constants.ts
@@ -62,4 +62,4 @@ export const METHOD_STATUS_CODES = {
  * Sentinel symbol to opt a controller out of versioning.
  * When used as the version, no prefix is applied even when defaultVersion is set.
  */
-export const VERSION_NEUTRAL: unique symbol = Symbol.for('stratal:version:neutral')
+export const VERSION_NEUTRAL = Symbol.for('stratal:version:neutral')

--- a/packages/core/src/router/constants.ts
+++ b/packages/core/src/router/constants.ts
@@ -57,3 +57,9 @@ export const METHOD_STATUS_CODES = {
   patch: 200,
   destroy: 200
 } as const
+
+/**
+ * Sentinel symbol to opt a controller out of versioning.
+ * When used as the version, no prefix is applied even when defaultVersion is set.
+ */
+export const VERSION_NEUTRAL: unique symbol = Symbol.for('stratal:version:neutral')

--- a/packages/core/src/router/decorators/controller.decorator.ts
+++ b/packages/core/src/router/decorators/controller.decorator.ts
@@ -1,7 +1,7 @@
 import { Transient } from '../../di/decorators'
 import { type Constructor } from '../../types'
 import { ROUTE_METADATA_KEYS } from '../constants'
-import type { ControllerOptions } from '../types'
+import { type ControllerOptions } from '../types'
 
 const CONTROLLER_ROUTE_KEY = ROUTE_METADATA_KEYS.CONTROLLER_ROUTE
 
@@ -65,4 +65,15 @@ export function getControllerRoute(target: object): string | undefined {
 export function getControllerOptions(target: object): ControllerOptions | undefined {
   const metadataTarget = typeof target === 'function' ? target : (target as { constructor: object }).constructor
   return Reflect.getMetadata(ROUTE_METADATA_KEYS.CONTROLLER_OPTIONS, metadataTarget) as ControllerOptions | undefined
+}
+
+/**
+ * Get the version from controller class metadata
+ *
+ * @param target - Controller class or instance
+ * @returns Version string, array, VERSION_NEUTRAL symbol, or undefined if not set
+ */
+export function getControllerVersion(target: object): ControllerOptions['version'] {
+  const options = getControllerOptions(target)
+  return options?.version
 }

--- a/packages/core/src/router/hono-app.ts
+++ b/packages/core/src/router/hono-app.ts
@@ -19,7 +19,7 @@ import { createLoggerMiddleware } from './middleware'
 import type { Middleware } from './middleware.interface'
 import { RouterContext } from './router-context'
 import { RouteRegistrationService } from './services/route-registration.service'
-import type { RouterEnv } from './types'
+import type { RouterEnv, VersioningOptions } from './types'
 
 const isMiddlewareClass = (arg: unknown): arg is Constructor<Middleware> =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -94,11 +94,15 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
    * Configure module middleware, OpenAPI endpoints, controller routes, and 404 handler.
    * Called once by Application.initialize().
    */
-  configure(middlewareConfigs: MiddlewareConfigEntry[], controllers: Constructor<IController>[]): void {
+  configure(
+    middlewareConfigs: MiddlewareConfigEntry[],
+    controllers: Constructor<IController>[],
+    versioningOptions?: VersioningOptions | null,
+  ): void {
     if (this.configured) throw new HonoAppAlreadyConfiguredError()
 
     // Module middleware
-    const middlewareConfigService = new MiddlewareConfigurationService(this._logger)
+    const middlewareConfigService = new MiddlewareConfigurationService(this._logger, versioningOptions ?? null)
     middlewareConfigService.applyMiddlewares(this, middlewareConfigs, controllers, this._container)
 
     // OpenAPI endpoints
@@ -106,7 +110,7 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
     openAPIService.setupEndpoints(this, controllers)
 
     // Controller routes
-    const routeRegistrationService = new RouteRegistrationService(this._logger)
+    const routeRegistrationService = new RouteRegistrationService(this._logger, versioningOptions ?? null)
     routeRegistrationService.configure(this, controllers)
 
     // 404 handler (must be last)

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -4,10 +4,10 @@
 // Core router types
 export type { IController } from './controller'
 export type { Middleware } from './middleware.interface'
-export type { ControllerOptions, HttpRouteMetadata, RouteConfig, RouterEnv, RouteResponse, RouterVariables, SecurityScheme } from './types'
+export type { ControllerOptions, HttpRouteMetadata, RouteConfig, RouterEnv, RouteResponse, RouterVariables, SecurityScheme, VersioningOptions } from './types'
 
 // Router constants
-export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEMES } from './constants'
+export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEMES, VERSION_NEUTRAL } from './constants'
 
 // Router context
 export { RouterContext } from './router-context'
@@ -25,7 +25,7 @@ export { ROUTER_TOKENS } from './router.tokens'
 
 // Decorators
 export {
-  Controller, getControllerOptions, getControllerRoute
+  Controller, getControllerOptions, getControllerRoute, getControllerVersion
 } from './decorators/controller.decorator'
 export { All, Delete, Get, getHttpDecoratedMethods, getHttpRouteMetadata, Patch, Post, Put } from './decorators/http-method.decorator'
 export { getDecoratedMethods, getRouteConfig, Route } from './decorators/route.decorator'

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -34,7 +34,9 @@ import type {
   RouteConfig,
   RouterEnv,
   SecuritySchemeRecord,
+  VersioningOptions,
 } from '../types'
+import { VERSION_NEUTRAL } from '../constants'
 
 /**
  * Route registration service
@@ -51,7 +53,8 @@ export class RouteRegistrationService {
   private controllerClasses = new Map<string, Constructor<IController>>()
 
   constructor(
-    private logger: LoggerService
+    private logger: LoggerService,
+    private versioningOptions: VersioningOptions | null = null,
   ) { }
 
   /**
@@ -107,34 +110,79 @@ export class RouteRegistrationService {
     const prototype = ControllerClass.prototype as IController
     const controllerOpts = getControllerOptions(ControllerClass)
 
-    // Handle wildcard routes (non-RESTful controllers)
-    if (prototype.handle) {
-      this.registerWildcardRoute(app, ControllerClass, route)
-      return
+    // Resolve versioned paths
+    const versionedPaths = this.resolveVersionedPaths(route, controllerOpts)
+
+    for (const versionedRoute of versionedPaths) {
+      // Handle wildcard routes (non-RESTful controllers)
+      if (prototype.handle) {
+        this.registerWildcardRoute(app, ControllerClass, versionedRoute)
+        continue
+      }
+
+      // Check for both decorator types
+      const decoratedMethods = getDecoratedMethods(ControllerClass)
+      const httpDecoratedMethods = getHttpDecoratedMethods(ControllerClass)
+
+      // Enforce mutual exclusivity: a controller cannot mix @Route() with HTTP method decorators
+      if (decoratedMethods.length > 0 && httpDecoratedMethods.length > 0) {
+        throw new ControllerRegistrationError(
+          ControllerClass.name,
+          'Cannot mix @Route() with HTTP method decorators (@Get, @Post, etc.) in the same controller. Use one pattern or the other.'
+        )
+      }
+
+      if (httpDecoratedMethods.length > 0) {
+        // Register explicit HTTP method routes (@Get, @Post, etc.)
+        this.registerHttpRoutes(app, ControllerClass, versionedRoute, httpDecoratedMethods, controllerOpts)
+      } else if (decoratedMethods.length > 0) {
+        // Register OpenAPI routes (@Route with convention-based method names)
+        this.registerOpenAPIRoutes(app, ControllerClass, versionedRoute, decoratedMethods, controllerOpts)
+      } else {
+        // Fallback to traditional RESTful method registration (no OpenAPI)
+        this.registerRESTfulRoutes(app, ControllerClass, versionedRoute, prototype)
+      }
+    }
+  }
+
+  /**
+   * Resolve versioned paths for a controller based on versioning configuration.
+   *
+   * @param basePath - The base path from @Controller decorator
+   * @param controllerOpts - Controller options (may contain version)
+   * @returns Array of resolved paths (with version prefix if applicable)
+   */
+  private resolveVersionedPaths(basePath: string, controllerOpts?: ControllerOptions): string[] {
+    // Versioning disabled — always return base path
+    if (!this.versioningOptions) {
+      return [basePath]
     }
 
-    // Check for both decorator types
-    const decoratedMethods = getDecoratedMethods(ControllerClass)
-    const httpDecoratedMethods = getHttpDecoratedMethods(ControllerClass)
+    const version = controllerOpts?.version
 
-    // Enforce mutual exclusivity: a controller cannot mix @Route() with HTTP method decorators
-    if (decoratedMethods.length > 0 && httpDecoratedMethods.length > 0) {
-      throw new ControllerRegistrationError(
-        ControllerClass.name,
-        'Cannot mix @Route() with HTTP method decorators (@Get, @Post, etc.) in the same controller. Use one pattern or the other.'
-      )
+    // VERSION_NEUTRAL — explicitly opt out of versioning
+    if (version === VERSION_NEUTRAL) {
+      return [basePath]
     }
 
-    if (httpDecoratedMethods.length > 0) {
-      // Register explicit HTTP method routes (@Get, @Post, etc.)
-      this.registerHttpRoutes(app, ControllerClass, route, httpDecoratedMethods, controllerOpts)
-    } else if (decoratedMethods.length > 0) {
-      // Register OpenAPI routes (@Route with convention-based method names)
-      this.registerOpenAPIRoutes(app, ControllerClass, route, decoratedMethods, controllerOpts)
-    } else {
-      // Fallback to traditional RESTful method registration (no OpenAPI)
-      this.registerRESTfulRoutes(app, ControllerClass, route, prototype)
+    const prefix = this.versioningOptions.prefix ?? 'v'
+
+    // Explicit version(s) on the controller
+    if (version !== undefined) {
+      const versions = Array.isArray(version) ? version : [version]
+      return versions.map(v => `/${prefix}${v}${basePath}`)
     }
+
+    // No explicit version — apply defaultVersion if set
+    if (this.versioningOptions.defaultVersion !== undefined) {
+      const defaults = Array.isArray(this.versioningOptions.defaultVersion)
+        ? this.versioningOptions.defaultVersion
+        : [this.versioningOptions.defaultVersion]
+      return defaults.map(v => `/${prefix}${v}${basePath}`)
+    }
+
+    // Versioning enabled but no version and no default — no prefix
+    return [basePath]
   }
 
   /**

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -134,26 +134,36 @@ export class RouteRegistrationService {
       )
     }
 
-    // Dispatch route registration for a single path
-    const registerForPath = (path: string): void => {
-      if (httpDecoratedMethods.length > 0) {
-        this.registerHttpRoutes(app, ControllerClass, path, httpDecoratedMethods, controllerOpts)
-      } else if (decoratedMethods.length > 0) {
-        this.registerOpenAPIRoutes(app, ControllerClass, path, decoratedMethods, controllerOpts)
-      } else {
-        this.registerRESTfulRoutes(app, ControllerClass, path, prototype)
-      }
-    }
-
-    // Fast path: no versioning — skip array allocation and loop
+    // Fast path: no versioning — inline dispatch, no array allocation, no loop
     if (!this.versioningOptions) {
-      registerForPath(route)
+      this.dispatchRoutes(app, ControllerClass, route, decoratedMethods, httpDecoratedMethods, controllerOpts, prototype)
       return
     }
 
     // Versioning path: resolve versioned paths and register each
     for (const versionedRoute of this.resolveVersionedPaths(route, controllerOpts)) {
-      registerForPath(versionedRoute)
+      this.dispatchRoutes(app, ControllerClass, versionedRoute, decoratedMethods, httpDecoratedMethods, controllerOpts, prototype)
+    }
+  }
+
+  /**
+   * Dispatch route registration based on decorator type
+   */
+  private dispatchRoutes(
+    app: OpenAPIHono<RouterEnv>,
+    ControllerClass: Constructor<IController>,
+    path: string,
+    decoratedMethods: string[],
+    httpDecoratedMethods: string[],
+    controllerOpts: ControllerOptions | undefined,
+    prototype: IController
+  ): void {
+    if (httpDecoratedMethods.length > 0) {
+      this.registerHttpRoutes(app, ControllerClass, path, httpDecoratedMethods, controllerOpts)
+    } else if (decoratedMethods.length > 0) {
+      this.registerOpenAPIRoutes(app, ControllerClass, path, decoratedMethods, controllerOpts)
+    } else {
+      this.registerRESTfulRoutes(app, ControllerClass, path, prototype)
     }
   }
 

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -110,38 +110,50 @@ export class RouteRegistrationService {
     const prototype = ControllerClass.prototype as IController
     const controllerOpts = getControllerOptions(ControllerClass)
 
-    // Resolve versioned paths
-    const versionedPaths = this.resolveVersionedPaths(route, controllerOpts)
-
-    for (const versionedRoute of versionedPaths) {
-      // Handle wildcard routes (non-RESTful controllers)
-      if (prototype.handle) {
-        this.registerWildcardRoute(app, ControllerClass, versionedRoute)
-        continue
-      }
-
-      // Check for both decorator types
-      const decoratedMethods = getDecoratedMethods(ControllerClass)
-      const httpDecoratedMethods = getHttpDecoratedMethods(ControllerClass)
-
-      // Enforce mutual exclusivity: a controller cannot mix @Route() with HTTP method decorators
-      if (decoratedMethods.length > 0 && httpDecoratedMethods.length > 0) {
-        throw new ControllerRegistrationError(
-          ControllerClass.name,
-          'Cannot mix @Route() with HTTP method decorators (@Get, @Post, etc.) in the same controller. Use one pattern or the other.'
-        )
-      }
-
-      if (httpDecoratedMethods.length > 0) {
-        // Register explicit HTTP method routes (@Get, @Post, etc.)
-        this.registerHttpRoutes(app, ControllerClass, versionedRoute, httpDecoratedMethods, controllerOpts)
-      } else if (decoratedMethods.length > 0) {
-        // Register OpenAPI routes (@Route with convention-based method names)
-        this.registerOpenAPIRoutes(app, ControllerClass, versionedRoute, decoratedMethods, controllerOpts)
+    // Handle wildcard routes (non-RESTful controllers) — check once, not per version
+    if (prototype.handle) {
+      if (!this.versioningOptions) {
+        this.registerWildcardRoute(app, ControllerClass, route)
       } else {
-        // Fallback to traditional RESTful method registration (no OpenAPI)
-        this.registerRESTfulRoutes(app, ControllerClass, versionedRoute, prototype)
+        for (const versionedRoute of this.resolveVersionedPaths(route, controllerOpts)) {
+          this.registerWildcardRoute(app, ControllerClass, versionedRoute)
+        }
       }
+      return
+    }
+
+    // Compute decorated methods once (loop-invariant)
+    const decoratedMethods = getDecoratedMethods(ControllerClass)
+    const httpDecoratedMethods = getHttpDecoratedMethods(ControllerClass)
+
+    // Enforce mutual exclusivity once
+    if (decoratedMethods.length > 0 && httpDecoratedMethods.length > 0) {
+      throw new ControllerRegistrationError(
+        ControllerClass.name,
+        'Cannot mix @Route() with HTTP method decorators (@Get, @Post, etc.) in the same controller. Use one pattern or the other.'
+      )
+    }
+
+    // Dispatch route registration for a single path
+    const registerForPath = (path: string): void => {
+      if (httpDecoratedMethods.length > 0) {
+        this.registerHttpRoutes(app, ControllerClass, path, httpDecoratedMethods, controllerOpts)
+      } else if (decoratedMethods.length > 0) {
+        this.registerOpenAPIRoutes(app, ControllerClass, path, decoratedMethods, controllerOpts)
+      } else {
+        this.registerRESTfulRoutes(app, ControllerClass, path, prototype)
+      }
+    }
+
+    // Fast path: no versioning — skip array allocation and loop
+    if (!this.versioningOptions) {
+      registerForPath(route)
+      return
+    }
+
+    // Versioning path: resolve versioned paths and register each
+    for (const versionedRoute of this.resolveVersionedPaths(route, controllerOpts)) {
+      registerForPath(versionedRoute)
     }
   }
 

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -1,7 +1,7 @@
 import type { ZodObject, ZodPipe, ZodType, RouteConfig as OpenAPIRouteConfig } from '../i18n/validation'
 import { type StratalEnv } from '../env'
 import type { Container } from '../di'
-import { type HTTP_METHODS, type ROUTER_CONTEXT_KEYS, type SECURITY_SCHEMES } from './constants'
+import { type HTTP_METHODS, type ROUTER_CONTEXT_KEYS, type SECURITY_SCHEMES, type VERSION_NEUTRAL } from './constants'
 
 /**
  * Route parameter type for OpenAPI
@@ -162,4 +162,32 @@ export interface ControllerOptions {
    * Useful for internal-only controllers, debug endpoints, or utilities
    */
   hideFromDocs?: boolean
+
+  /**
+   * API version(s) for this controller.
+   * When versioning is enabled, routes are prefixed with the version (e.g., /v1/users).
+   * Use VERSION_NEUTRAL to opt out of versioning (no prefix applied).
+   * Can be a single version string, array of versions, or VERSION_NEUTRAL symbol.
+   */
+  version?: string | string[] | typeof VERSION_NEUTRAL
 }
+
+/**
+ * Versioning configuration for the application.
+ * Enables URI-based API versioning when provided to Stratal config.
+ */
+export interface VersioningOptions {
+  /**
+   * Prefix for version segments in the URL.
+   * @default 'v'
+   * @example 'v' produces /v1, /v2; 'api/v' produces /api/v1, /api/v2
+   */
+  prefix?: string
+
+  /**
+   * Default version applied to controllers without explicit version.
+   * Controllers with VERSION_NEUTRAL are not affected.
+   */
+  defaultVersion?: string | string[]
+}
+


### PR DESCRIPTION
## Summary
Adds URI-based API versioning to Stratal, allowing controllers to be served under versioned paths (e.g., `/v1/users`, `/v2/users`). Configured via a `versioning` option on `Stratal` config with support for per-controller versions, multi-version controllers, `VERSION_NEUTRAL` opt-out, `defaultVersion`, custom prefixes, and version-targeted middleware.

## How to Test
- Run `yarn workspace stratal test src/router/__tests__/versioning.spec.ts` to verify versioning logic
- Run `yarn workspace stratal test` to confirm no regressions
- Run `yarn workspace stratal typecheck` to validate types
- Review `RouteRegistrationService.resolveVersionedPaths()` for path resolution logic
- Review `MiddlewareConfigurationService.resolveVersionedRouteInfo()` for middleware version targeting