### PR TITLE
feat(core): replace Scalar with Swagger UI and add pluggable docs renderer

### DIFF
--- a/.changeset/pluggable-docs-renderer-core.md
+++ b/.changeset/pluggable-docs-renderer-core.md
@@ -1,0 +1,25 @@
+---
+"stratal": patch
+---
+
+Replace Scalar with Swagger UI as the default OpenAPI docs renderer and add pluggable UI support
+
+### Details
+
+- Replace `@scalar/hono-api-reference` dependency with `@hono/swagger-ui`
+- Add `OpenAPIUIRenderer` type for custom docs UI renderers
+- Add `ui` option to `OpenAPIModuleOptions` with `path` and `renderer` fields
+- Support disabling docs UI entirely by setting `ui: false`
+- Remove `docsPath` option in favor of `ui.path` (default remains `/api/docs`)
+
+### Breaking Changes
+
+- The `docsPath` option in `OpenAPIModuleOptions` has been removed. Use `ui.path` instead:
+  ```ts
+  // Before
+  OpenAPIModule.forRoot({ docsPath: '/docs' })
+
+  // After
+  OpenAPIModule.forRoot({ ui: { path: '/docs' } })
+  ```
+- The default docs UI is now Swagger UI instead of Scalar. To use a custom renderer (e.g., Scalar), provide a `ui.renderer` function.

--- a/examples/08-openapi/.gitignore
+++ b/examples/08-openapi/.gitignore
@@ -1,0 +1,2 @@
+.wrangler
+worker-configuration.d.ts

--- a/examples/08-openapi/README.md
+++ b/examples/08-openapi/README.md
@@ -1,6 +1,6 @@
 # 08 - OpenAPI
 
-OpenAPI documentation with Scalar UI and richly documented routes.
+OpenAPI documentation with Swagger UI and richly documented routes.
 
 ## What it demonstrates
 
@@ -8,7 +8,7 @@ OpenAPI documentation with Scalar UI and richly documented routes.
 - Zod schemas with `.openapi('SchemaName')` for named OpenAPI components
 - `@Route()` with `summary`, `description`, and `tags` fields
 - `@Controller()` with `tags` option for grouping routes
-- Scalar UI for interactive API exploration
+- Swagger UI for interactive API exploration
 
 ## Running
 
@@ -21,7 +21,7 @@ npx wrangler dev
 
 | URL                          | Description             |
 |------------------------------|-------------------------|
-| http://localhost:8787/api/docs         | Scalar UI              |
+| http://localhost:8787/api/docs         | Swagger UI              |
 | http://localhost:8787/api/openapi.json | Raw OpenAPI spec       |
 | http://localhost:8787/api/users        | Users CRUD API         |
 

--- a/examples/08-openapi/package-lock.json
+++ b/examples/08-openapi/package-lock.json
@@ -1138,13 +1138,30 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.2.8.tgz",
-      "integrity": "sha512-nBq6Y1tVkjIUsLsdOjDSJj4AsjvD0UG3zsg9Fyc+OivwlA/oMHSKooUy9tpKj0HqZ+NWFifweHavdljlBLTwdA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.3.0.tgz",
+      "integrity": "sha512-NNX5jIwF4TJBe7RtSKDMOA6JD9mp2mRcBHAwt2X+Q8PvnZub0yj5YYXlFu2AcESdgQpEv/5Yx2uOCV/yh7YkZg==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "11.2.8",
-        "@intlify/shared": "11.2.8"
+        "@intlify/devtools-types": "11.3.0",
+        "@intlify/message-compiler": "11.3.0",
+        "@intlify/shared": "11.3.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.3.0.tgz",
+      "integrity": "sha512-G9CNL4WpANWVdUjubOIIS7/D2j/0j+1KJmhBJxHilWNKr9mmt3IjFV3Hq4JoBP23uOoC5ynxz/FHZ42M+YxfGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.3.0",
+        "@intlify/shared": "11.3.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1154,12 +1171,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.2.8.tgz",
-      "integrity": "sha512-A5n33doOjmHsBtCN421386cG1tWp5rpOjOYPNsnpjIJbQ4POF0QY2ezhZR9kr0boKwaHjbOifvyQvHj2UTrDFQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.0.tgz",
+      "integrity": "sha512-RAJp3TMsqohg/Wa7bVF3cChRhecSYBLrTCQSj7j0UtWVFLP+6iEJoE2zb7GU5fp+fmG5kCbUdzhmlAUCWXiUJw==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "11.2.8",
+        "@intlify/shared": "11.3.0",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -1170,9 +1187,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.2.8.tgz",
-      "integrity": "sha512-l6e4NZyUgv8VyXXH4DbuucFOBmxLF56C/mqh2tvApbzl2Hrhi1aTDcuv5TKdxzfHYmpO3UB0Cz04fgDT9vszfw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -1239,48 +1256,48 @@
       "license": "MIT"
     },
     "node_modules/@scalar/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-Zcl+V8oBxb0S7vR+Nro8J53GD/w/kSjuyX0UoT3r1sn0bUM3Buf4Ob44n3CSfluQzxmiMuZxfOROHqa9F+ckbg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.4.3.tgz",
+      "integrity": "sha512-Fp/J5RyajknwZrDG5/nsJRxL07cS2gJ9wvnvIWcFgsR8HWy/7qMQ+PtpYhdBmMYiBAql1JJobKTu/7ZWqnHaFA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.7.0"
+        "@scalar/types": "0.7.3"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.3.0.tgz",
-      "integrity": "sha512-lhQdehgighJC+PiSTJbbggM/SM3UydcRQil6Cfp/M4l539qklIh35pt4eh1+H+5Esa03gHnJwhTHF3TwglSOJw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.1.tgz",
+      "integrity": "sha512-XfyYqSUA597wfzS8lmMY1xvYv4si2WytuoBWj7JDpx3E/lVq7YEsticXF/Q30ttFVRBfgQErg8MQI6b6IkZr2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/hono-api-reference": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.10.0.tgz",
-      "integrity": "sha512-5QGNilMAnLRzSufMhh0Ni8DepWzL2UOJm+RQI+e/slrhhfhO+pSV2bcLE8dhBz6k+V70El6Pvl0m2cPaDvP4sw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.10.3.tgz",
+      "integrity": "sha512-bdueh25lDTx8US5qJux4L3LlkXwqe64kUnPEGqFmjAYfNfDJI3KknCgq43P9aikO07wnqpPNRYGj8sxOEubidw==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/core": "0.4.0"
+        "@scalar/core": "0.4.3"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
-        "hono": "^4.11.5"
+        "hono": "^4.12.5"
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.0.tgz",
-      "integrity": "sha512-IkG62M4ztmqkYNVhLpcswBojlQctbXLdkDa3UFsY8FfT7yfZ2LppjptycW9tWjD09ZQb4QAZ070FAUHmFRIS7w==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.3.tgz",
+      "integrity": "sha512-9ThydMH28aA5DMm8Q/nTKXKnAKejG7Awlj7IC99oXkq5aOJ60Sn0kS1RWaqQosaWI3ezyPJ7/sUglssAEMA6EA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.3.0",
+        "@scalar/helpers": "0.4.1",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
@@ -1571,17 +1588,17 @@
       }
     },
     "node_modules/stratal": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stratal/-/stratal-0.0.6.tgz",
-      "integrity": "sha512-hUjnDk0YGYbVHrgxFFsGwl4Xg4hykdHi9Vog6bZsUzLSZhc538JTMf29l7uDauKgd6xfYhuxC5TdCkgQqKI1PQ==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/stratal/-/stratal-0.0.12.tgz",
+      "integrity": "sha512-WTMp1PHrRkk0XpdCjqpOmJ+T3r2vgb/qSm3tCfdWC2mmiKDo8iMMJfqRSGSrO/BsZL60KyqOtEUoqL/deWpKMQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/zod-openapi": "^1.2.2",
-        "@intlify/core-base": "^11.2.8",
-        "@intlify/message-compiler": "^11.2.8",
-        "@scalar/hono-api-reference": "^0.10.0",
+        "@intlify/core-base": "^11.3.0",
+        "@intlify/message-compiler": "^11.3.0",
+        "@scalar/hono-api-reference": "^0.10.3",
         "@xmldom/xmldom": "^0.8.11",
-        "hono": "^4.12.3",
+        "hono": "^4.12.8",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.10.0",
         "zod": "^4.3.6"

--- a/examples/08-openapi/src/index.ts
+++ b/examples/08-openapi/src/index.ts
@@ -1,4 +1,6 @@
-import { Stratal } from 'stratal'
-import { AppModule } from './app.module'
+import 'reflect-metadata';
+
+import { Stratal } from 'stratal';
+import { AppModule } from './app.module';
 
 export default new Stratal({ module: AppModule })

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ npx wrangler dev
 | 05 | [middleware](05-middleware/) | Middleware configuration with `MiddlewareConfigurable` |
 | 06 | [queues](06-queues/) | Queue producer/consumer pattern with Cloudflare Queues |
 | 07 | [scheduled-tasks](07-scheduled-tasks/) | Cron job scheduling with the `CronJob` interface |
-| 08 | [openapi](08-openapi/) | OpenAPI documentation with Scalar UI |
+| 08 | [openapi](08-openapi/) | OpenAPI documentation with Swagger UI |
 | 09 | [seeders](09-seeders/) | Database seeding with `@stratal/seeders` and the `stratal-seed` CLI |
 | 10 | [events](10-events/) | Type-safe event system with `@Listener` and `@On` decorators |
 | 11 | [auth](11-auth/) | Session-based authentication with Better Auth and `AuthGuard` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,7 +56,7 @@ Available templates:
 | `middleware` | Middleware configuration with apply/exclude/forRoutes | [Source](https://github.com/strataljs/stratal/tree/main/examples/05-middleware) |
 | `queues` | Queue producer/consumer pattern with Cloudflare Queues | [Source](https://github.com/strataljs/stratal/tree/main/examples/06-queues) |
 | `scheduled-tasks` | Cron job scheduling with the CronJob interface | [Source](https://github.com/strataljs/stratal/tree/main/examples/07-scheduled-tasks) |
-| `openapi` | OpenAPI docs with Scalar UI and Zod schema integration | [Source](https://github.com/strataljs/stratal/tree/main/examples/08-openapi) |
+| `openapi` | OpenAPI docs with Swagger UI and Zod schema integration | [Source](https://github.com/strataljs/stratal/tree/main/examples/08-openapi) |
 
 For benchmarks, see the [main README](https://github.com/strataljs/stratal#benchmarks).
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,10 +80,10 @@
     "lint:fix": "npx eslint --fix ."
   },
   "dependencies": {
+    "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^1.2.2",
     "@intlify/core-base": "^11.3.0",
     "@intlify/message-compiler": "^11.3.0",
-    "@scalar/hono-api-reference": "^0.10.3",
     "@xmldom/xmldom": "^0.8.11",
     "hono": "^4.12.8",
     "reflect-metadata": "^0.2.2",

--- a/packages/core/src/openapi/index.ts
+++ b/packages/core/src/openapi/index.ts
@@ -11,6 +11,9 @@ export type {
   OpenAPIEffectiveConfig,
   OpenAPIInfo,
   OpenAPIModuleOptions,
+  OpenAPIUIContext,
+  OpenAPIUIOptions,
+  OpenAPIUIRenderer,
   RouteFilterFn
 } from './types'
 

--- a/packages/core/src/openapi/openapi.module.ts
+++ b/packages/core/src/openapi/openapi.module.ts
@@ -48,7 +48,6 @@ import type { OpenAPIModuleOptions } from './types'
 /** Default options when none provided */
 const DEFAULT_OPTIONS: OpenAPIModuleOptions = {
   jsonPath: '/api/openapi.json',
-  docsPath: '/api/docs',
   info: {
     title: 'API',
     version: '1.0.0'

--- a/packages/core/src/openapi/services/openapi-config.service.ts
+++ b/packages/core/src/openapi/services/openapi-config.service.ts
@@ -53,7 +53,7 @@ export class OpenAPIConfigService implements IOpenAPIConfigService {
     // Start with base options and defaults
     let effective: OpenAPIEffectiveConfig = {
       jsonPath: this.baseOptions?.jsonPath ?? '/api/openapi.json',
-      docsPath: this.baseOptions?.docsPath ?? '/api/docs',
+      ui: this.baseOptions?.ui,
       info: {
         title: this.baseOptions?.info?.title ?? 'API',
         version: this.baseOptions?.info?.version ?? '1.0.0',

--- a/packages/core/src/openapi/services/openapi.service.ts
+++ b/packages/core/src/openapi/services/openapi.service.ts
@@ -1,4 +1,4 @@
-import { Scalar } from '@scalar/hono-api-reference'
+import { swaggerUI } from '@hono/swagger-ui'
 import { inject } from 'tsyringe'
 import { Transient } from '../../di/decorators'
 import type { II18nService } from '../../i18n'
@@ -96,21 +96,26 @@ export class OpenAPIService {
       return c.json(fullSpec)
     })
 
-    // Swagger UI endpoint
-    app.get(config.docsPath, (c, next) => {
-      const requestContainer = c.get(ROUTER_CONTEXT_KEYS.REQUEST_CONTAINER)
-      const requestConfigService = requestContainer.resolve<IOpenAPIConfigService>(
-        OPENAPI_TOKENS.ConfigService
-      )
-      const effectiveConfig = requestConfigService.getEffectiveConfig()
+    // Docs UI endpoint
+    if (config.ui !== false) {
+      const uiPath = config.ui?.path ?? '/api/docs'
+      const uiRenderer = config.ui?.renderer
 
-      return Scalar<RouterEnv>({
-        url: effectiveConfig.jsonPath,
-        pageTitle: effectiveConfig.info.title,
-        telemetry: false,
-        theme: 'deepSpace',
-      })(c, next)
-    })
+      app.get(uiPath, (c, next) => {
+        const requestContainer = c.get(ROUTER_CONTEXT_KEYS.REQUEST_CONTAINER)
+        const requestConfigService = requestContainer.resolve<IOpenAPIConfigService>(
+          OPENAPI_TOKENS.ConfigService
+        )
+        const effectiveConfig = requestConfigService.getEffectiveConfig()
+        const uiContext = { specUrl: effectiveConfig.jsonPath, title: effectiveConfig.info.title }
+
+        if (uiRenderer) {
+          return uiRenderer(uiContext)(c, next)
+        }
+
+        return swaggerUI<RouterEnv>({ url: uiContext.specUrl })(c, next)
+      })
+    }
   }
 
   /**

--- a/packages/core/src/openapi/types.ts
+++ b/packages/core/src/openapi/types.ts
@@ -1,4 +1,6 @@
+import type { MiddlewareHandler } from 'hono/types'
 import type { PathItemObject } from '../i18n/validation'
+import type { RouterEnv } from '../router/types'
 
 /**
  * OpenAPI Info section configuration
@@ -10,20 +12,44 @@ export interface OpenAPIInfo {
 }
 
 /**
+ * Context passed to a custom OpenAPI UI renderer
+ */
+export interface OpenAPIUIContext {
+  specUrl: string
+  title: string
+}
+
+/**
+ * Custom UI renderer function
+ * Returns a Hono middleware handler that serves the docs UI
+ */
+export type OpenAPIUIRenderer = (context: OpenAPIUIContext) => MiddlewareHandler<RouterEnv>
+
+/**
+ * Options for the docs UI
+ */
+export interface OpenAPIUIOptions {
+  /** Path for docs UI (default: '/api/docs') */
+  path?: string
+  /** Custom UI renderer (default: swagger UI) */
+  renderer?: OpenAPIUIRenderer
+}
+
+/**
  * Static module configuration (provided via forRoot)
  */
 export interface OpenAPIModuleOptions {
   /** Path for OpenAPI JSON spec (default: '/api/openapi.json') */
   jsonPath?: string
 
-  /** Path for Swagger UI docs (default: '/api/docs') */
-  docsPath?: string
-
   /** Default info section for spec */
   info?: OpenAPIInfo
 
   /** Security schemes definition */
   securitySchemes?: Record<string, object>
+
+  /** Docs UI configuration. Set to false to disable. (default: swagger UI at /api/docs) */
+  ui?: OpenAPIUIOptions | false
 }
 
 /**
@@ -48,10 +74,10 @@ export interface OpenAPIConfigOverride {
  */
 export interface OpenAPIEffectiveConfig {
   jsonPath: string
-  docsPath: string
   info: OpenAPIInfo
   securitySchemes?: Record<string, object>
   routeFilter?: RouteFilterFn
+  ui?: OpenAPIUIOptions | false
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,6 +1756,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/swagger-ui@npm:^0.5.0":
+  version: 0.5.3
+  resolution: "@hono/swagger-ui@npm:0.5.3"
+  peerDependencies:
+    hono: ">=4.0.0"
+  checksum: 10c0/c1acf638aa8b2fdf1c237f15233a8071621f7a65a29a179296141aa019208c89fb4e9bf76139fdf9589e2b505ebf96e89db088a8783c3d60eeacf7d5d5d1a5a5
+  languageName: node
+  linkType: hard
+
 "@hono/zod-openapi@npm:^1.2.2":
   version: 1.2.2
   resolution: "@hono/zod-openapi@npm:1.2.2"
@@ -3006,45 +3015,6 @@ __metadata:
   version: 1.0.0-rc.9
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.9"
   checksum: 10c0/fca488fb96b134ccf95b42632b6112b4abb8b3a9688f166fbd627410def2538ee201953717d234ddecbff62dfe4edc4e72c657b01a9d0750134608d767eea5fd
-  languageName: node
-  linkType: hard
-
-"@scalar/core@npm:0.4.3":
-  version: 0.4.3
-  resolution: "@scalar/core@npm:0.4.3"
-  dependencies:
-    "@scalar/types": "npm:0.7.3"
-  checksum: 10c0/75f868fcf89b6d3c0be5ce3711eb650f5b793fc9cfe669c3eca4c9d9540f87a1d55457248c67e474aa2763fba0b83034665cb2a1e2f692f16fa4bc33e25ee6df
-  languageName: node
-  linkType: hard
-
-"@scalar/helpers@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@scalar/helpers@npm:0.4.1"
-  checksum: 10c0/c2d9de0a8afb549d695c5e5e2a23b3bf5ea44cd61e2a21fd504cb2834704044948eb4a856c5ff5347c10696d908c4d75a66cef0a40e54dcde551aefb5fd65e20
-  languageName: node
-  linkType: hard
-
-"@scalar/hono-api-reference@npm:^0.10.3":
-  version: 0.10.3
-  resolution: "@scalar/hono-api-reference@npm:0.10.3"
-  dependencies:
-    "@scalar/core": "npm:0.4.3"
-  peerDependencies:
-    hono: ^4.12.5
-  checksum: 10c0/315c0eda2bef550036d1556c515dea28d8e7d5006ad58dec315ec49d0e6582d9da2d3b4724b3e521c26308b7adb4fb5cff3165d221309dc55d473bf15b158ec5
-  languageName: node
-  linkType: hard
-
-"@scalar/types@npm:0.7.3":
-  version: 0.7.3
-  resolution: "@scalar/types@npm:0.7.3"
-  dependencies:
-    "@scalar/helpers": "npm:0.4.1"
-    nanoid: "npm:^5.1.6"
-    type-fest: "npm:^5.3.1"
-    zod: "npm:^4.3.5"
-  checksum: 10c0/19fd23feebd772923e120b24b541bb633db13cd1705b3e50d35847b27d2f42ee8fcc279adf62053d018204d95300a0fbae3eec6a141dd3332aa4fcdf16b3d2af
   languageName: node
   linkType: hard
 
@@ -7771,7 +7741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.0.9, nanoid@npm:^5.1.6":
+"nanoid@npm:^5.0.9":
   version: 5.1.6
   resolution: "nanoid@npm:5.1.6"
   bin:
@@ -9319,11 +9289,11 @@ __metadata:
     "@aws-sdk/s3-request-presigner": "npm:3.1009.0"
     "@cloudflare/vitest-pool-workers": "patch:@cloudflare/vitest-pool-workers@npm%3A0.13.0#~/.yarn/patches/@cloudflare-vitest-pool-workers-npm-0.13.0-47105599c6.patch"
     "@cloudflare/workers-types": "npm:4.20260313.1"
+    "@hono/swagger-ui": "npm:^0.5.0"
     "@hono/zod-openapi": "npm:^1.2.2"
     "@intlify/core-base": "npm:^11.3.0"
     "@intlify/message-compiler": "npm:^11.3.0"
     "@react-email/components": "npm:^1.0.9"
-    "@scalar/hono-api-reference": "npm:^0.10.3"
     "@stratal/testing": "workspace:*"
     "@tus/server": "npm:^2.3.0"
     "@types/node": "npm:^25.5.0"
@@ -9719,7 +9689,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^5.2.0, type-fest@npm:^5.3.1":
+"type-fest@npm:^5.2.0":
   version: 5.4.4
   resolution: "type-fest@npm:5.4.4"
   dependencies:
@@ -10430,7 +10400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.0.0, zod@npm:^4.3.5, zod@npm:^4.3.6":
+"zod@npm:^4.0.0, zod@npm:^4.3.6":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307


### PR DESCRIPTION
## Summary

Swaps `@scalar/hono-api-reference` for `@hono/swagger-ui` as the default OpenAPI docs renderer and introduces an `OpenAPIUIRenderer` abstraction so users can plug in any docs UI (or disable it entirely). The `docsPath` option is replaced by `ui: { path, renderer }`.

## How to Test

- Run `yarn workspace stratal build` and verify it compiles
- Start the `08-openapi` example and confirm Swagger UI loads at `/api/docs`
- Pass `ui: false` to `OpenAPIModule.forRoot()` and verify no docs route is registered
- Pass a custom `ui.renderer` function and verify it renders instead of Swagger UI

## Breaking Changes

- `docsPath` option removed from `OpenAPIModuleOptions` — use `ui.path` instead:
  ```ts
  // Before
  OpenAPIModule.forRoot({ docsPath: '/docs' })
  // After
  OpenAPIModule.forRoot({ ui: { path: '/docs' } })