### PR TITLE
feat(router): add configurable content type support for request and response bodies

### DIFF
--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -11,7 +11,9 @@ description: >-
   registerAs, StratalDurableObject, StratalWorkerEntrypoint, StratalWorkflow, runInScope,
   stratal/workers, DurableObject, Workflow, WorkerEntrypoint, Service Binding, RPC,
   @Get, @Post, @Put, @Patch, @Delete, @All, HttpRouteMetadata, RouteConfig,
-  versioning, VERSION_NEUTRAL, VersioningOptions, defaultVersion, version prefix, API versioning.
+  versioning, VERSION_NEUTRAL, VersioningOptions, defaultVersion, version prefix, API versioning,
+  RouteBody, RouteBodyObject, RouteResponse, RouteResponseObject, contentType, content type,
+  multipart/form-data, application/octet-stream, DEFAULT_CONTENT_TYPE.
 user-invocable: false
 license: MIT
 metadata:
@@ -131,6 +133,18 @@ export class UsersController implements IController {
 **Available decorators:** `@Get(path, config?)`, `@Post(path, config?)`, `@Put(path, config?)`, `@Patch(path, config?)`, `@Delete(path, config?)`, `@All(path, config?)`.
 
 **`RouteConfig` options:** `body`, `params`, `query`, `response` (required), `tags`, `security`, `description`, `summary`, `statusCode`, `hideFromDocs`.
+
+**Custom content types:** `body` and `response` accept an object form with optional `contentType` (defaults to `application/json`):
+
+```ts
+@Route({
+  body: { schema: UploadSchema, contentType: 'multipart/form-data' },
+  response: { schema: FileSchema, contentType: 'application/octet-stream', description: 'Binary file' },
+})
+async upload(ctx: RouterContext) { /* ... */ }
+```
+
+Types: `RouteBody = ZodType | RouteBodyObject`, `RouteResponse = ZodType | RouteResponseObject`. Error responses always use `application/json` regardless of route content type.
 
 **Key rules:**
 - HTTP method decorators and `@Route()` **cannot be mixed** in the same controller — use one pattern or the other
@@ -425,7 +439,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 |---|---|
 | `stratal` | `Stratal`, `Application`, `@Module`, `StratalEnv` |
 | `stratal/di` | `Container`, `DI_TOKENS`, `Scope`, `inject`, `Transient` |
-| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouterContext`, `UseGuards`, `IController`, `VERSION_NEUTRAL`, `VersioningOptions` |
+| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouteBody`, `RouteBodyObject`, `RouteResponse`, `RouteResponseObject`, `RouterContext`, `UseGuards`, `IController`, `VERSION_NEUTRAL`, `VersioningOptions` |
 | `stratal/validation` | `z` (Zod), `ZodType`, validation utilities |
 | `stratal/errors` | `ApplicationError`, `ERROR_CODES`, built-in error classes |
 | `stratal/events` | `@Listener`, `@On`, `EventRegistry` |

--- a/.changeset/content-type-support-core.md
+++ b/.changeset/content-type-support-core.md
@@ -1,0 +1,14 @@
+---
+"stratal": patch
+---
+
+Add configurable content type support for request and response bodies in route definitions
+
+### Details
+
+- Add `RouteBodyObject` and `RouteResponseObject` types with optional `contentType` field
+- Support `{ schema, contentType }` object form for `body` and `response` in `@Route()` config
+- Bare `ZodType` values default to `application/json` (backward-compatible)
+- Export new types: `RouteBody`, `RouteBodyObject`, `RouteResponseObject`
+- Add `DEFAULT_CONTENT_TYPE` constant
+- Error response schemas always use `application/json` regardless of route content type

--- a/packages/core/src/router/__tests__/content-type.spec.ts
+++ b/packages/core/src/router/__tests__/content-type.spec.ts
@@ -1,0 +1,117 @@
+import { createMock } from '@stratal/testing/mocks'
+import { describe, expect, it } from 'vitest'
+import { z, type RouteConfig as OpenAPIRouteConfig } from '../../i18n/validation'
+import type { LoggerService } from '../../logger/services/logger.service'
+import { DEFAULT_CONTENT_TYPE } from '../constants'
+import { RouteRegistrationService } from '../services/route-registration.service'
+import type { RouteConfig } from '../types'
+
+const mockLogger = createMock<LoggerService>()
+
+interface RouteRegistrationServicePrivate {
+  buildOpenAPIRoute(
+    method: string,
+    path: string,
+    routeConfig: RouteConfig,
+    metadata: { tags: string[]; security: Record<string, string[]>[] },
+    guards: [],
+    methodName?: string,
+    statusCodeOverride?: number
+  ): OpenAPIRouteConfig
+}
+
+const createService = () => {
+  const service = new RouteRegistrationService(mockLogger as unknown as LoggerService, null)
+  return service as unknown as RouteRegistrationServicePrivate
+}
+
+const defaultMetadata = { tags: [], security: [] }
+const testSchema = z.object({ name: z.string() })
+
+type AnyRecord = Record<string, unknown>
+
+describe('Content Type Support', () => {
+  describe('request body', () => {
+    it('should default to application/json for bare ZodType body', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('post', '/test', {
+        body: testSchema,
+        response: testSchema,
+      }, defaultMetadata, [])
+
+      expect(route.request?.body?.content).toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+
+    it('should use custom contentType for body object form', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('post', '/test', {
+        body: { schema: testSchema, contentType: 'multipart/form-data' },
+        response: testSchema,
+      }, defaultMetadata, [])
+
+      expect(route.request?.body?.content).toHaveProperty('multipart/form-data')
+      expect(route.request?.body?.content).not.toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+
+    it('should default to application/json when body object omits contentType', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('post', '/test', {
+        body: { schema: testSchema },
+        response: testSchema,
+      }, defaultMetadata, [])
+
+      expect(route.request?.body?.content).toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+  })
+
+  describe('response', () => {
+    it('should default to application/json for bare ZodType response', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('get', '/test', {
+        response: testSchema,
+      }, defaultMetadata, [])
+
+      const successResponse = (route.responses as AnyRecord)[200] as AnyRecord
+      expect(successResponse.content).toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+
+    it('should use custom contentType for response object form', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('get', '/test', {
+        response: { schema: testSchema, contentType: 'application/octet-stream' },
+      }, defaultMetadata, [])
+
+      const successResponse = (route.responses as AnyRecord)[200] as AnyRecord
+      expect(successResponse.content).toHaveProperty('application/octet-stream')
+      expect(successResponse.content).not.toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+
+    it('should default to application/json when response object omits contentType', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('get', '/test', {
+        response: { schema: testSchema, description: 'File' },
+      }, defaultMetadata, [])
+
+      const successResponse = (route.responses as AnyRecord)[200] as AnyRecord
+      expect(successResponse.content).toHaveProperty(DEFAULT_CONTENT_TYPE)
+    })
+  })
+
+  describe('error schemas', () => {
+    it('should keep error schemas as application/json regardless of route content type', () => {
+      const service = createService()
+      const route = service.buildOpenAPIRoute('post', '/test', {
+        body: { schema: testSchema, contentType: 'multipart/form-data' },
+        response: { schema: testSchema, contentType: 'application/octet-stream' },
+      }, defaultMetadata, [])
+
+      // Check that error responses (400, 401, etc.) still use application/json
+      for (const status of [400, 401, 403, 404, 409, 500]) {
+        const errorResponse = (route.responses as AnyRecord)[status] as AnyRecord | undefined
+        if (errorResponse?.content) {
+          expect(errorResponse.content).toHaveProperty(DEFAULT_CONTENT_TYPE)
+        }
+      }
+    })
+  })
+})

--- a/packages/core/src/router/constants.ts
+++ b/packages/core/src/router/constants.ts
@@ -63,3 +63,8 @@ export const METHOD_STATUS_CODES = {
  * When used as the version, no prefix is applied even when defaultVersion is set.
  */
 export const VERSION_NEUTRAL = Symbol.for('stratal:version:neutral')
+
+/**
+ * Default content type for request bodies and responses
+ */
+export const DEFAULT_CONTENT_TYPE = 'application/json'

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -4,7 +4,7 @@
 // Core router types
 export type { IController } from './controller'
 export type { Middleware } from './middleware.interface'
-export type { ControllerOptions, HttpRouteMetadata, RouteConfig, RouterEnv, RouteResponse, RouterVariables, SecurityScheme, VersioningOptions } from './types'
+export type { ControllerOptions, HttpRouteMetadata, RouteBody, RouteBodyObject, RouteConfig, RouterEnv, RouteResponse, RouteResponseObject, RouterVariables, SecurityScheme, VersioningOptions } from './types'
 
 // Router constants
 export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEMES, VERSION_NEUTRAL } from './constants'

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -10,7 +10,7 @@ import type { OpenAPIHono } from '../../i18n/validation'
 import { createRoute } from '../../i18n/validation'
 import { type LoggerService } from '../../logger'
 import type { Constructor } from '../../types'
-import { HTTP_METHODS, METHOD_STATUS_CODES, SECURITY_SCHEMES } from '../constants'
+import { DEFAULT_CONTENT_TYPE, HTTP_METHODS, METHOD_STATUS_CODES, SECURITY_SCHEMES } from '../constants'
 import type { IController } from '../controller'
 import {
   getControllerOptions,
@@ -31,6 +31,7 @@ import type {
   ControllerOptions,
   HttpMethod,
   OpenAPIRouteConfig,
+  RouteBodyObject,
   RouteConfig,
   RouterEnv,
   SecuritySchemeRecord,
@@ -618,12 +619,15 @@ export class RouteRegistrationService {
 
       // Add request body if defined
       if (routeConfig.body) {
+        const bodySchema = this.isRouteBodyObject(routeConfig.body) ? routeConfig.body.schema : routeConfig.body
+        const bodyContentType = this.isRouteBodyObject(routeConfig.body) ? routeConfig.body.contentType ?? DEFAULT_CONTENT_TYPE : DEFAULT_CONTENT_TYPE
+
         route.request = {
           ...route.request,
           body: {
             content: {
-              'application/json': {
-                schema: routeConfig.body,
+              [bodyContentType]: {
+                schema: bodySchema,
               },
             },
           },
@@ -659,16 +663,17 @@ export class RouteRegistrationService {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- response may be undefined at runtime
       if (responseDef) {
         if (typeof responseDef === 'object' && 'schema' in responseDef) {
+          const responseContentType = responseDef.contentType ?? DEFAULT_CONTENT_TYPE
           responses[successStatus] = {
             content: {
-              'application/json': { schema: responseDef.schema },
+              [responseContentType]: { schema: responseDef.schema },
             },
             description: responseDef.description ?? `Response ${successStatus}`,
           }
         } else {
           responses[successStatus] = {
             content: {
-              'application/json': { schema: responseDef },
+              [DEFAULT_CONTENT_TYPE]: { schema: responseDef },
             },
             description: `Response ${successStatus}`,
           }
@@ -707,6 +712,13 @@ export class RouteRegistrationService {
     } catch (error) {
       throw new OpenAPIRouteRegistrationError(path, error instanceof Error ? error.message : String(error))
     }
+  }
+
+  /**
+   * Check if a body definition is a RouteBodyObject (has schema key) vs bare ZodType
+   */
+  private isRouteBodyObject(body: RouteConfig['body']): body is RouteBodyObject {
+    return typeof body === 'object' && 'schema' in body
   }
 
   /**

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -56,10 +56,26 @@ export type SecuritySchemeRecord = Record<SecurityScheme, string[]>
 export type { OpenAPIRouteConfig }
 
 /**
+ * Object form for request body with optional content type
+ */
+export interface RouteBodyObject { schema: ZodType; contentType?: string }
+
+/**
+ * Request body definition for @Route() decorator
+ * Bare ZodType defaults to application/json
+ */
+export type RouteBody = ZodType | RouteBodyObject
+
+/**
+ * Object form for response with optional description and content type
+ */
+export interface RouteResponseObject { schema: ZodType; description?: string; contentType?: string }
+
+/**
  * Single response definition for @Route() decorator
  * Status code is auto-derived from method name (create->201, others->200)
  */
-export type RouteResponse = ZodType | { schema: ZodType; description?: string }
+export type RouteResponse = ZodType | RouteResponseObject
 
 /**
  * Route configuration for @Route() decorator
@@ -68,8 +84,9 @@ export type RouteResponse = ZodType | { schema: ZodType; description?: string }
 export interface RouteConfig {
   /**
    * Request body schema (for POST, PUT, PATCH)
+   * @example z.object({}) or { schema: z.object({}), contentType: 'multipart/form-data' }
    */
-  body?: ZodType
+  body?: RouteBody
 
   /**
    * URL parameters schema (e.g., { id: z.string().uuid() })


### PR DESCRIPTION
## Summary

Adds support for custom content types (e.g., `multipart/form-data`, `application/octet-stream`) in `@Route()` body and response definitions. Bare `ZodType` values remain backward-compatible, defaulting to `application/json`.

## How to Test

- Run `yarn workspace stratal test src/router/__tests__/content-type.spec.ts`
- Verify bare `ZodType` body/response still defaults to `application/json`
- Verify `{ schema, contentType }` object form sets the custom content type
- Verify error response schemas always use `application/json` regardless of route content type