### PR TITLE
feat(router): add streaming response methods to RouterContext

### DIFF
--- a/.changeset/streaming-responses-core.md
+++ b/.changeset/streaming-responses-core.md
@@ -1,0 +1,12 @@
+---
+"stratal": patch
+---
+
+Add streaming response methods (`stream`, `streamText`, `streamSSE`) to RouterContext
+
+### Details
+
+- `stream()` — generic/binary streaming via Hono's `stream` helper
+- `streamText()` — text streaming with automatic `Content-Encoding: Identity` for Cloudflare Workers compatibility
+- `streamSSE()` — Server-Sent Events streaming with automatic `Content-Encoding: Identity` for Cloudflare Workers compatibility
+- Re-export `StreamingApi`, `SSEStreamingApi`, and `SSEMessage` types from `stratal/router`

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -12,6 +12,10 @@ export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEME
 // Router context
 export { RouterContext } from './router-context'
 
+// Streaming types
+export type { StreamingApi } from 'hono/utils/stream'
+export type { SSEStreamingApi, SSEMessage } from 'hono/streaming'
+
 // HonoApp
 export { HonoApp } from './hono-app'
 

--- a/packages/core/src/router/router-context.ts
+++ b/packages/core/src/router/router-context.ts
@@ -1,5 +1,8 @@
 import type { Context } from 'hono'
-import { type ContentfulStatusCode, type RedirectStatusCode } from 'hono/utils/http-status'
+import { stream as honoStream, streamText as honoStreamText, streamSSE as honoStreamSSE } from 'hono/streaming'
+import type { SSEStreamingApi } from 'hono/streaming'
+import type { ContentfulStatusCode, RedirectStatusCode } from 'hono/utils/http-status'
+import type { StreamingApi } from 'hono/utils/stream'
 import type { Container } from '../di/container'
 import { RequestContainerNotInitializedError } from '../errors'
 import { ROUTER_CONTEXT_KEYS } from './constants'
@@ -157,5 +160,41 @@ export class RouterContext<T extends RouterEnv = RouterEnv> {
    */
   redirect(url: string, status?: RedirectStatusCode): Response {
     return this.c.redirect(url, status)
+  }
+
+  /**
+   * Return a streaming response (binary/generic)
+   *
+   * @param callback - Async function that writes to the stream
+   * @param onError - Optional error handler called if an error occurs during streaming
+   */
+  stream(callback: (stream: StreamingApi) => Promise<void>, onError?: (err: Error, stream: StreamingApi) => Promise<void>): Response {
+    return honoStream(this.c, callback, onError)
+  }
+
+  /**
+   * Return a streaming text response
+   *
+   * Automatically sets `Content-Encoding: Identity` for Cloudflare Workers compatibility.
+   *
+   * @param callback - Async function that writes text to the stream
+   * @param onError - Optional error handler called if an error occurs during streaming
+   */
+  streamText(callback: (stream: StreamingApi) => Promise<void>, onError?: (err: Error, stream: StreamingApi) => Promise<void>): Response {
+    this.c.header('Content-Encoding', 'Identity')
+    return honoStreamText(this.c, callback, onError)
+  }
+
+  /**
+   * Return a Server-Sent Events (SSE) streaming response
+   *
+   * Automatically sets `Content-Encoding: Identity` for Cloudflare Workers compatibility.
+   *
+   * @param callback - Async function that writes SSE events to the stream
+   * @param onError - Optional error handler called if an error occurs during streaming
+   */
+  streamSSE(callback: (stream: SSEStreamingApi) => Promise<void>, onError?: (err: Error, stream: SSEStreamingApi) => Promise<void>): Response {
+    this.c.header('Content-Encoding', 'Identity')
+    return honoStreamSSE(this.c, callback, onError)
   }
 }

--- a/packages/core/test/fixtures/streaming.controller.ts
+++ b/packages/core/test/fixtures/streaming.controller.ts
@@ -1,0 +1,48 @@
+import { z } from '../../src/i18n/validation'
+import { Module } from '../../src/module/module.decorator'
+import { Controller } from '../../src/router/decorators/controller.decorator'
+import { Get } from '../../src/router/decorators/http-method.decorator'
+import type { RouterContext } from '../../src/router/router-context'
+
+@Controller('/streaming')
+export class StreamingController {
+  @Get('/stream', { response: { schema: z.any(), contentType: 'application/octet-stream' } })
+  stream(ctx: RouterContext) {
+    return ctx.stream(async (stream) => {
+      await stream.write(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+  }
+
+  @Get('/stream-error', { response: { schema: z.any(), contentType: 'application/octet-stream' } })
+  streamError(ctx: RouterContext) {
+    return ctx.stream(
+      () => {
+        throw new Error('stream error')
+      },
+      async (err, stream) => {
+        await stream.writeln(err.message)
+        await stream.close()
+      }
+    )
+  }
+
+  @Get('/text', { response: { schema: z.any(), contentType: 'text/plain' } })
+  text(ctx: RouterContext) {
+    return ctx.streamText(async (stream) => {
+      await stream.write('hello ')
+      await stream.write('world')
+    })
+  }
+
+  @Get('/sse', { response: { schema: z.any(), contentType: 'text/event-stream' } })
+  sse(ctx: RouterContext) {
+    return ctx.streamSSE(async (stream) => {
+      await stream.writeSSE({ data: 'hello', event: 'message', id: '1' })
+    })
+  }
+}
+
+@Module({
+  controllers: [StreamingController],
+})
+export class StreamingAppModule {}

--- a/packages/core/test/integration/streaming.spec.ts
+++ b/packages/core/test/integration/streaming.spec.ts
@@ -1,0 +1,81 @@
+import { Test, type TestingModule } from '@stratal/testing'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { StreamingAppModule } from '../fixtures/streaming.controller'
+
+describe('Streaming', () => {
+  let module: TestingModule
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [StreamingAppModule],
+    }).compile()
+  })
+
+  afterAll(async () => {
+    await module.close()
+  })
+
+  describe('stream()', () => {
+    it('should return a Response with a readable body', async () => {
+      const response = await module.http.get('/streaming/stream').send()
+
+      response.assertOk()
+
+      const text = await response.raw.text()
+      expect(text).toBe('Hello')
+    })
+
+    it('should invoke the error callback on stream error', async () => {
+      const response = await module.http.get('/streaming/stream-error').send()
+
+      const text = await response.raw.text()
+      expect(text.includes('stream error')).toBe(true)
+    })
+  })
+
+  describe('streamText()', () => {
+    it('should set Content-Encoding to Identity', async () => {
+      const response = await module.http.get('/streaming/text').send()
+
+      response.assertHeader('Content-Encoding', 'Identity')
+    })
+
+    it('should stream text content', async () => {
+      const response = await module.http.get('/streaming/text').send()
+
+      const text = await response.raw.text()
+      expect(text).toBe('hello world')
+    })
+
+    it('should set Content-Type to text/plain', async () => {
+      const response = await module.http.get('/streaming/text').send()
+
+      const contentType = response.headers.get('Content-Type') ?? ''
+      expect(contentType.includes('text/plain')).toBe(true)
+    })
+  })
+
+  describe('streamSSE()', () => {
+    it('should set Content-Encoding to Identity', async () => {
+      const response = await module.http.get('/streaming/sse').send()
+
+      response.assertHeader('Content-Encoding', 'Identity')
+    })
+
+    it('should produce SSE-formatted output', async () => {
+      const response = await module.http.get('/streaming/sse').send()
+
+      const text = await response.raw.text()
+      expect(text.includes('event: message')).toBe(true)
+      expect(text.includes('data: hello')).toBe(true)
+      expect(text.includes('id: 1')).toBe(true)
+    })
+
+    it('should set Content-Type to text/event-stream', async () => {
+      const response = await module.http.get('/streaming/sse').send()
+
+      const contentType = response.headers.get('Content-Type') ?? ''
+      expect(contentType.includes('text/event-stream')).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add `stream()`, `streamText()`, and `streamSSE()` methods to `RouterContext`, wrapping Hono's streaming helpers with automatic `Content-Encoding: Identity` for Cloudflare Workers compatibility on text/SSE streams. Re-exports `StreamingApi`, `SSEStreamingApi`, and `SSEMessage` types from `stratal/router`.

## How to Test
- `yarn workspace stratal test test/integration/streaming.spec.ts`
- Verify `stream()` returns binary data and invokes error callback on failure
- Verify `streamText()` sets `Content-Encoding: Identity` and streams text
- Verify `streamSSE()` produces SSE-formatted output with correct headers