### PR TITLE
feat(core, testing): add WebSocket gateway support and SSE testing utilities

### DIFF
--- a/.agents/skills/stratal-testing/SKILL.md
+++ b/.agents/skills/stratal-testing/SKILL.md
@@ -181,11 +181,11 @@ const sse = await module.sse('/streaming/sse')
   .withHeaders({ 'X-Custom': 'value' })
   .connect();
 
-// Collect all events
-const events = await sse.collectEvents();
-
 // Assert JSON event data
 await sse.assertJsonEventData({ status: 'complete', count: 42 });
+
+// Collect all remaining events
+const events = await sse.collectEvents();
 ```
 
 ## FakeStorageService

--- a/.agents/skills/stratal-testing/SKILL.md
+++ b/.agents/skills/stratal-testing/SKILL.md
@@ -2,14 +2,15 @@
 name: stratal-testing
 description: >-
   Use when writing tests for Stratal applications — TestingModule, HTTP testing,
-  mocks, fakes, and auth testing utilities. Trigger on: test, TestingModule,
+  WebSocket testing, mocks, fakes, and auth testing utilities. Trigger on: test, TestingModule,
   TestHttpClient, TestResponse, mock, fake, FakeStorageService, createMockFetch,
-  MockFetch, msw, stratalTest, createMock, ActingAs, @stratal/testing.
+  MockFetch, msw, stratalTest, createMock, ActingAs, @stratal/testing,
+  TestWsRequest, TestWsConnection, ws, WebSocket, websocket, module.ws.
 user-invocable: false
 license: MIT
 metadata:
   author: Temitayo Fadojutimi
-  version: "3.0"
+  version: "3.1"
 ---
 
 # @stratal/testing
@@ -94,6 +95,48 @@ await response.assertJsonPath('data.email', 'test@example.com');
 ```
 
 Assertion methods: `assertOk()`, `assertCreated()`, `assertNotFound()`, `assertUnauthorized()`, `assertForbidden()`, `assertStatus(code)`, `assertJsonPath(path, value)`, `assertJsonStructure(shape)`.
+
+## WebSocket Testing
+
+Docs: [WebSocket Testing](https://stratal.dev/testing/websocket-testing)
+
+Use `module.ws(path)` to create a WebSocket test request builder (`TestWsRequest`). Call `.connect()` to perform the upgrade and get a `TestWsConnection`.
+
+```ts
+const ws = await module.ws('/ws/chat').connect();
+
+// Send a message and assert the response
+ws.send('hello');
+await ws.assertMessage('echo:hello');
+
+// Close and assert
+ws.close();
+await ws.assertClosed();
+```
+
+**`TestWsRequest`** (builder pattern):
+- `.withHeaders(headers)` — add custom headers to the upgrade request
+- `.actingAs({ id })` — authenticate the WebSocket connection as a user
+- `.connect()` — send the upgrade request, returns `TestWsConnection`
+
+**`TestWsConnection`** methods:
+- `send(data)` — send a string, ArrayBuffer, or Uint8Array
+- `close(code?, reason?)` — close the connection
+- `raw` — access the underlying WebSocket
+
+**`TestWsConnection`** assertions:
+- `assertMessage(expected, timeout?)` — assert the next message equals `expected`
+- `assertClosed(expectedCode?, timeout?)` — assert the connection closes
+- `waitForMessage(timeout?)` — wait for and return the next message
+- `waitForClose(timeout?)` — wait for the connection to close
+
+```ts
+// Authenticated WebSocket
+const ws = await module.ws('/ws/chat')
+  .actingAs({ id: user.id })
+  .withHeaders({ 'X-Custom': 'value' })
+  .connect();
+```
 
 ## FakeStorageService
 

--- a/.agents/skills/stratal-testing/SKILL.md
+++ b/.agents/skills/stratal-testing/SKILL.md
@@ -2,15 +2,16 @@
 name: stratal-testing
 description: >-
   Use when writing tests for Stratal applications — TestingModule, HTTP testing,
-  WebSocket testing, mocks, fakes, and auth testing utilities. Trigger on: test, TestingModule,
+  WebSocket testing, SSE testing, mocks, fakes, and auth testing utilities. Trigger on: test, TestingModule,
   TestHttpClient, TestResponse, mock, fake, FakeStorageService, createMockFetch,
   MockFetch, msw, stratalTest, createMock, ActingAs, @stratal/testing,
-  TestWsRequest, TestWsConnection, ws, WebSocket, websocket, module.ws.
+  TestWsRequest, TestWsConnection, ws, WebSocket, websocket, module.ws,
+  TestSseRequest, TestSseConnection, TestSseEvent, sse, SSE, Server-Sent Events, module.sse.
 user-invocable: false
 license: MIT
 metadata:
   author: Temitayo Fadojutimi
-  version: "3.1"
+  version: "3.2"
 ---
 
 # @stratal/testing
@@ -136,6 +137,55 @@ const ws = await module.ws('/ws/chat')
   .actingAs({ id: user.id })
   .withHeaders({ 'X-Custom': 'value' })
   .connect();
+```
+
+## SSE Testing
+
+Docs: [SSE Testing](https://stratal.dev/testing/sse-testing)
+
+Use `module.sse(path)` to create an SSE test request builder (`TestSseRequest`). Call `.connect()` to perform the request and get a `TestSseConnection`.
+
+```ts
+const sse = await module.sse('/streaming/sse').connect();
+
+// Assert individual events
+await sse.assertEvent({ event: 'message', data: 'hello' });
+await sse.assertEventData('world');
+
+// Wait for stream to end
+await sse.waitForEnd();
+```
+
+**`TestSseRequest`** (builder pattern):
+- `.withHeaders(headers)` — add custom headers to the request
+- `.actingAs({ id })` — authenticate the SSE connection as a user
+- `.connect()` — send the request, returns `TestSseConnection`
+
+**`TestSseConnection`** methods:
+- `waitForEvent(timeout?)` — wait for and return the next `TestSseEvent`
+- `waitForEnd(timeout?)` — wait for the stream to end
+- `collectEvents(timeout?)` — collect all remaining events until the stream ends
+- `raw` — access the underlying `Response`
+
+**`TestSseConnection`** assertions:
+- `assertEvent(expected, timeout?)` — assert the next event matches a partial `TestSseEvent`
+- `assertEventData(expected, timeout?)` — assert the next event's data equals the expected string
+- `assertJsonEventData(expected, timeout?)` — assert the next event's data is JSON matching the expected value
+
+**`TestSseEvent`** interface: `{ data: string, event?: string, id?: string, retry?: number }`
+
+```ts
+// Authenticated SSE with custom headers
+const sse = await module.sse('/streaming/sse')
+  .actingAs({ id: user.id })
+  .withHeaders({ 'X-Custom': 'value' })
+  .connect();
+
+// Collect all events
+const events = await sse.collectEvents();
+
+// Assert JSON event data
+await sse.assertJsonEventData({ status: 'complete', count: 42 });
 ```
 
 ## FakeStorageService

--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -3,7 +3,7 @@ name: stratal
 description: >-
   Use when working with the Stratal core framework for Cloudflare Workers — modules,
   dependency injection, controllers, routing, OpenAPI, queues, cron, email, storage,
-  caching, i18n, logging, guards, middleware, config, events, and error handling.
+  caching, i18n, logging, guards, middleware, config, events, SSE, streaming, and error handling.
   Trigger on: stratal, Stratal, StratalWorker, @Module, @Controller, @Route, IController,
   RouterContext, @inject, Scope, @Listener, @On, queues, cron, email, storage, cache,
   i18n, logging, guards, middleware, config, OpenAPIModule, ConfigModule, CacheModule,
@@ -13,12 +13,15 @@ description: >-
   @Get, @Post, @Put, @Patch, @Delete, @All, HttpRouteMetadata, RouteConfig,
   versioning, VERSION_NEUTRAL, VersioningOptions, defaultVersion, version prefix, API versioning,
   RouteBody, RouteBodyObject, RouteResponse, RouteResponseObject, contentType, content type,
-  multipart/form-data, application/octet-stream, DEFAULT_CONTENT_TYPE.
+  multipart/form-data, application/octet-stream, DEFAULT_CONTENT_TYPE,
+  @Gateway, @OnMessage, @OnClose, @OnError, GatewayContext, WebSocket, websocket, gateway,
+  stratal/websocket, streamSSE, SSEStreamingApi, SSEMessage, StreamingApi, stream, streamText,
+  text/event-stream, SSE, streaming, Server-Sent Events.
 user-invocable: false
 license: MIT
 metadata:
   author: Temitayo Fadojutimi
-  version: "3.0"
+  version: "3.1"
 ---
 
 # Stratal Core Framework
@@ -150,6 +153,119 @@ Types: `RouteBody = ZodType | RouteBodyObject`, `RouteResponse = ZodType | Route
 - HTTP method decorators and `@Route()` **cannot be mixed** in the same controller — use one pattern or the other
 - Default status code is `200` for all methods; use `statusCode: 201` explicitly for POST create endpoints
 - `@All` routes are **automatically hidden** from OpenAPI docs (OpenAPI doesn't support catch-all HTTP methods)
+
+## WebSocket Gateways
+
+Docs: [WebSocket](https://stratal.dev/integrations/websocket)
+
+Use `@Gateway(path, options?)` to create WebSocket endpoints. Gateways are registered in the module's `controllers` array (not a separate array). The `@Gateway` decorator auto-applies `@Transient()`. Accepts optional `GatewayOptions` (from `stratal/websocket`) with `version` support — same as `@Controller`.
+
+```ts
+import { Gateway, OnMessage, OnClose, OnError } from 'stratal/websocket';
+import type { GatewayContext } from 'stratal/websocket';
+
+@Gateway('/ws/chat', { version: '1' })
+export class ChatGateway {
+  constructor(@inject(ChatService) private chatService: ChatService) {}
+
+  @OnMessage()
+  handleMessage(evt: MessageEvent, ctx: GatewayContext) {
+    ctx.send(`echo:${evt.data as string}`);
+  }
+
+  @OnClose()
+  handleClose(evt: CloseEvent, ctx: GatewayContext) {
+    console.log('Connection closed');
+  }
+
+  @OnError()
+  handleError(evt: Event, ctx: GatewayContext) {
+    console.error('WebSocket error', evt);
+  }
+}
+```
+
+```ts
+@Module({
+  controllers: [ChatGateway], // gateways go in controllers array
+  providers: [ChatService],
+})
+export class ChatModule {}
+```
+
+**Method decorators:** `@OnMessage()`, `@OnClose()`, `@OnError()` — each marks exactly one method per gateway.
+
+**`GatewayContext`** extends `RouterContext` with:
+- `send(data)` — send a string, ArrayBuffer, or Uint8Array through the WebSocket
+- `close(code?, reason?)` — close the WebSocket connection
+- `readyState` — current WebSocket ready state
+- `ws` — raw Hono `WSContext`
+- Inherits `header()`, `getContainer()`, `getLocale()` from `RouterContext`
+- Overrides `param()` and `query()` to use raw Hono request methods (no OpenAPI validation, since WebSocket upgrades bypass OpenAPI)
+- `body()` throws `WebSocketBodyNotAvailableError` — WebSocket upgrade requests have no body
+
+**Guards** work on the upgrade request via `@UseGuards()` — applied the same way as on controllers.
+
+**Note:** Hono's `onOpen` event is not supported on Cloudflare Workers (the connection is already open when the server receives it).
+
+## Streaming & SSE
+
+Docs: [Streaming](https://stratal.dev/core-concepts/streaming)
+
+`RouterContext` provides three streaming methods that wrap Hono's streaming utilities:
+
+### `ctx.stream()` — Generic/binary streaming
+
+```ts
+@Get('/download', { response: { schema: z.any(), contentType: 'application/octet-stream' } })
+async download(ctx: RouterContext) {
+  return ctx.stream(async (stream) => {
+    await stream.write(new Uint8Array([1, 2, 3]));
+    await stream.close();
+  });
+}
+```
+
+**Signature:** `stream(callback: (stream: StreamingApi) => Promise<void>, onError?: (err: Error, stream: StreamingApi) => Promise<void>): Response`
+
+### `ctx.streamText()` — Text streaming
+
+Automatically sets `Content-Encoding: Identity` for Cloudflare Workers compatibility.
+
+```ts
+@Get('/generate', { response: { schema: z.any(), contentType: 'text/plain' } })
+async generate(ctx: RouterContext) {
+  return ctx.streamText(async (stream) => {
+    await stream.write('Hello ');
+    await stream.write('World');
+    await stream.close();
+  });
+}
+```
+
+**Signature:** `streamText(callback: (stream: StreamingApi) => Promise<void>, onError?: (err: Error, stream: StreamingApi) => Promise<void>): Response`
+
+### `ctx.streamSSE()` — Server-Sent Events
+
+Automatically sets `Content-Encoding: Identity` for Cloudflare Workers compatibility.
+
+```ts
+import type { SSEStreamingApi } from 'stratal/router';
+
+@Get('/events', { response: { schema: z.any(), contentType: 'text/event-stream' } })
+async events(ctx: RouterContext) {
+  return ctx.streamSSE(async (stream) => {
+    await stream.writeSSE({ data: JSON.stringify({ status: 'connected' }), event: 'open', id: '1' });
+    await stream.writeSSE({ data: JSON.stringify({ message: 'hello' }), event: 'message', id: '2' });
+  });
+}
+```
+
+**Signature:** `streamSSE(callback: (stream: SSEStreamingApi) => Promise<void>, onError?: (err: Error, stream: SSEStreamingApi) => Promise<void>): Response`
+
+**SSE message format:** `writeSSE({ data: string, event?: string, id?: string })` — the `data` field is required, `event` and `id` are optional.
+
+**Exported types from `stratal/router`:** `SSEStreamingApi`, `SSEMessage`, `StreamingApi`.
 
 ## API Versioning
 
@@ -439,7 +555,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 |---|---|
 | `stratal` | `Stratal`, `Application`, `@Module`, `StratalEnv` |
 | `stratal/di` | `Container`, `DI_TOKENS`, `Scope`, `inject`, `Transient` |
-| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouteBody`, `RouteBodyObject`, `RouteResponse`, `RouteResponseObject`, `RouterContext`, `UseGuards`, `IController`, `VERSION_NEUTRAL`, `VersioningOptions` |
+| `stratal/router` | `@Controller`, `@Route`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@All`, `RouteConfig`, `RouteBody`, `RouteBodyObject`, `RouteResponse`, `RouteResponseObject`, `RouterContext`, `UseGuards`, `IController`, `VERSION_NEUTRAL`, `VersioningOptions`, `SSEStreamingApi`, `SSEMessage`, `StreamingApi` |
 | `stratal/validation` | `z` (Zod), `ZodType`, validation utilities |
 | `stratal/errors` | `ApplicationError`, `ERROR_CODES`, built-in error classes |
 | `stratal/events` | `@Listener`, `@On`, `EventRegistry` |
@@ -451,6 +567,7 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 | `stratal/logger` | `LoggerService`, `LOGGER_TOKENS` |
 | `stratal/config` | `ConfigModule`, `registerAs` |
 | `stratal/openapi` | `OpenAPIModule` |
+| `stratal/websocket` | `@Gateway`, `@OnMessage`, `@OnClose`, `@OnError`, `GatewayContext` |
 | `stratal/workers` | `StratalDurableObject`, `StratalWorkerEntrypoint`, `StratalWorkflow`, `runInScope` |
 
 ## Do's and Don'ts
@@ -471,4 +588,6 @@ export class MyWorkflow extends StratalWorkflow<Env, { orderId: string }> {
 - **Do** use separate controllers for different API versions when behavior diverges
 - **Do** use `VERSION_NEUTRAL` for version-agnostic endpoints (health checks, OpenAPI docs, etc.)
 - **Don't** mix versioned and unversioned controllers for the same path without `VERSION_NEUTRAL`
+- **Do** register gateways in the `controllers` array (not a separate array)
+- **Don't** mix `@Gateway` with `@Controller` on the same class
 - **Don't** disable `emitDecoratorMetadata` in tsconfig

--- a/.changeset/add-sse-testing-utilities-testing.md
+++ b/.changeset/add-sse-testing-utilities-testing.md
@@ -1,0 +1,12 @@
+---
+"@stratal/testing": patch
+---
+
+Add SSE testing utilities with `TestSseRequest` and `TestSseConnection`
+
+### Details
+
+- `TestingModule.sse(path)` creates an SSE test request builder
+- `TestSseRequest` supports custom headers, authentication via `actingAs()`, and automatic `Accept: text/event-stream` header
+- `TestSseConnection` wraps a live SSE stream with assertion helpers: `assertEvent()`, `assertEventData()`, `assertJsonEventData()`, `waitForEvent()`, `waitForEnd()`, `collectEvents()`
+- Replace dynamic `import('vitest')` with static imports in `TestWsConnection`, `TestWsRequest`, and `TestingModule`

--- a/.changeset/add-websocket-gateway-core.md
+++ b/.changeset/add-websocket-gateway-core.md
@@ -1,0 +1,15 @@
+---
+"stratal": patch
+---
+
+Add WebSocket gateway support with `@Gateway`, `@OnMessage`, `@OnClose`, and `@OnError` decorators
+
+### Details
+
+- `@Gateway(path, options?)` decorator marks a class as a WebSocket gateway, reusing controller route metadata for middleware compatibility. Accepts optional `GatewayOptions` with `version` support (single, array, or `VERSION_NEUTRAL`)
+- `@OnMessage()`, `@OnClose()`, `@OnError()` method decorators wire handler methods to WebSocket events
+- `GatewayContext` extends `RouterContext` with WebSocket-specific methods (`send()`, `close()`, `readyState`)
+- `GatewayContext` overrides `param()` and `query()` to use raw Hono request methods (no OpenAPI validation for WebSocket upgrade requests)
+- `GatewayContext.body()` throws `WebSocketBodyNotAvailableError` — WebSocket upgrade requests have no body
+- Gateways support versioning and class-level guards
+- New `stratal/websocket` sub-path export with `GatewayOptions` type

--- a/.changeset/add-websocket-gateway-testing.md
+++ b/.changeset/add-websocket-gateway-testing.md
@@ -1,0 +1,11 @@
+---
+"@stratal/testing": patch
+---
+
+Add WebSocket testing utilities with `TestWsRequest` and `TestWsConnection`
+
+### Details
+
+- `TestingModule.ws(path)` creates a WebSocket test request builder
+- `TestWsRequest` supports custom headers, authentication via `actingAs()`, and WebSocket upgrade handshake
+- `TestWsConnection` wraps a live WebSocket with assertion helpers: `assertMessage()`, `assertClosed()`, `waitForMessage()`, `waitForClose()`

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,6 +45,10 @@ reviews:
       instructions: >
         Casbin-based RBAC with ZenStack database adapter.
         Check permission model consistency and CasbinService usage.
+    - path: .agents/**
+      instructions: >
+        AI agent skill definitions for Stratal packages. Ensure instructions
+        are accurate to the framework's actual API and conventions.
     - path: .github/workflows/**
       instructions: >
         CI/CD workflows. Ensure pinned action versions (use SHA, not tags),

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,76 @@
+language: en-US
+early_access: true
+
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  sequence_diagrams: true
+  changed_files_summary: true
+  labeling_instructions:
+    - label: core
+      instructions: Apply when changes affect `packages/core/`
+    - label: testing
+      instructions: Apply when changes affect `packages/testing/`
+    - label: framework
+      instructions: Apply when changes affect `packages/framework/`
+    - label: seeders
+      instructions: Apply when changes affect `packages/seeders/`
+  path_instructions:
+    - path: packages/core/src/di/**
+      instructions: >
+        DI container using tsyringe. Pay attention to singleton vs request scope.
+        Ensure correct use of @inject decorators and Symbol-based tokens.
+    - path: packages/core/src/router/**
+      instructions: >
+        Hono-based routing with OpenAPI generation via @hono/zod-openapi.
+        Check zod schema consistency and proper use of @Controller/@Route decorators.
+    - path: packages/core/src/module/**
+      instructions: >
+        Module system with NestJS-style @Module() decorator pattern.
+        Check lifecycle hooks (OnInitialize, OnShutdown), imports, and provider declarations.
+    - path: packages/framework/src/database/**
+      instructions: >
+        ZenStack ORM with multiple named connections and plugin system.
+        Check plugin ordering, schema registry augmentation, and @InjectDB usage.
+    - path: packages/framework/src/auth/**
+      instructions: >
+        Better Auth integration with session verification middleware pipeline.
+        Check AuthContext, AuthService, and middleware ordering.
+    - path: packages/framework/src/rbac/**
+      instructions: >
+        Casbin-based RBAC with ZenStack database adapter.
+        Check permission model consistency and CasbinService usage.
+    - path: .github/workflows/**
+      instructions: >
+        CI/CD workflows. Ensure pinned action versions (use SHA, not tags),
+        minimal permissions, and security best practices.
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/coverage/**"
+    - "!**/.yarn/**"
+    - "!**/*.tsbuildinfo"
+    - "!examples/**"
+    - "!docs/**"
+    - "!packages/framework/test/zenstack/**"
+    - "!**/*.lock"
+    - "!yarn.lock"
+  tools:
+    eslint:
+      enabled: true
+    biome:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/i18n/validation/index.d.ts",
       "import": "./dist/i18n/validation/index.js"
     },
+    "./websocket": {
+      "types": "./dist/websocket/index.d.ts",
+      "import": "./dist/websocket/index.js"
+    },
     "./*": {
       "types": "./dist/*/index.d.ts",
       "import": "./dist/*/index.js"

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -148,7 +148,7 @@ export class Application {
     this.honoApp = new HonoApp(this._container, logger)
     const middlewareConfigs = this.moduleRegistry.getAllMiddlewareConfigs()
     const controllers = this.moduleRegistry.getAllControllers() as Constructor<IController>[]
-    this.honoApp.configure(middlewareConfigs, controllers, this.appConfig.versioning)
+    await this.honoApp.configure(middlewareConfigs, controllers, this.appConfig.versioning)
 
     // Phase 6: Configure queues, cron, events
     this.registerQueueConsumers()

--- a/packages/core/src/errors/error-codes.ts
+++ b/packages/core/src/errors/error-codes.ts
@@ -185,6 +185,8 @@ export const ERROR_CODES = {
     CRON_EXECUTION_FAILED: 9204,
     /** Queue provider not supported */
     QUEUE_PROVIDER_NOT_SUPPORTED: 9205,
+    /** body() called on WebSocket gateway context */
+    WEBSOCKET_BODY_NOT_AVAILABLE: 9206,
   },
 } as const
 

--- a/packages/core/src/errors/error-codes.ts
+++ b/packages/core/src/errors/error-codes.ts
@@ -187,6 +187,8 @@ export const ERROR_CODES = {
     QUEUE_PROVIDER_NOT_SUPPORTED: 9205,
     /** body() called on WebSocket gateway context */
     WEBSOCKET_BODY_NOT_AVAILABLE: 9206,
+    /** Duplicate WebSocket event decorator on a gateway */
+    WEBSOCKET_DUPLICATE_EVENT_HANDLER: 9207,
   },
 } as const
 

--- a/packages/core/src/i18n/messages/en/errors.ts
+++ b/packages/core/src/i18n/messages/en/errors.ts
@@ -21,6 +21,7 @@ export const errors = {
 
   // WebSocket errors
   websocketBodyNotAvailable: 'body() is not available in WebSocket gateways. Use WebSocket messages instead.',
+  websocketDuplicateEventHandler: '@{decorator}() is already applied to \'{existingMethod}\'. Only one method per gateway can handle this event.',
 
   // Context errors
   contextNotInitialized: 'Context has not been initialized',

--- a/packages/core/src/i18n/messages/en/errors.ts
+++ b/packages/core/src/i18n/messages/en/errors.ts
@@ -19,6 +19,9 @@ export const errors = {
   controllerMethodNotFound: 'Method {methodName} not found on {controllerName}',
   controllerRegistration: 'Failed to register controller {controllerName}: {reason}',
 
+  // WebSocket errors
+  websocketBodyNotAvailable: 'body() is not available in WebSocket gateways. Use WebSocket messages instead.',
+
   // Context errors
   contextNotInitialized: 'Context has not been initialized',
   userNotAuthenticated: 'User is not authenticated',

--- a/packages/core/src/router/__benchmarks__/route-registration.bench.ts
+++ b/packages/core/src/router/__benchmarks__/route-registration.bench.ts
@@ -83,22 +83,22 @@ class SimpleController {
 }
 
 describe('RouteRegistration - Configure', () => {
-  bench('register controller with 5 OpenAPI routes', () => {
+  bench('register controller with 5 OpenAPI routes', async () => {
     const service = new RouteRegistrationService(noopLogger)
     const app = new OpenAPIHono<RouterEnv>()
-    service.configure(app, [ItemsController as unknown as Constructor<IController>])
+    await service.configure(app, [ItemsController as unknown as Constructor<IController>])
   })
 
-  bench('register single-route controller', () => {
+  bench('register single-route controller', async () => {
     const service = new RouteRegistrationService(noopLogger)
     const app = new OpenAPIHono<RouterEnv>()
-    service.configure(app, [SimpleController as unknown as Constructor<IController>])
+    await service.configure(app, [SimpleController as unknown as Constructor<IController>])
   })
 
-  bench('register multiple controllers', () => {
+  bench('register multiple controllers', async () => {
     const service = new RouteRegistrationService(noopLogger)
     const app = new OpenAPIHono<RouterEnv>()
-    service.configure(app, [
+    await service.configure(app, [
       ItemsController as unknown as Constructor<IController>,
       SimpleController as unknown as Constructor<IController>,
     ])

--- a/packages/core/src/router/constants.ts
+++ b/packages/core/src/router/constants.ts
@@ -19,7 +19,11 @@ export const ROUTE_METADATA_KEYS = {
   DECORATED_METHODS: Symbol.for('stratal:decorated:methods'),
   HTTP_ROUTE_CONFIG: Symbol.for('stratal:http-route:config'),
   HTTP_DECORATED_METHODS: Symbol.for('stratal:http-decorated:methods'),
-  AUTH_GUARD: Symbol.for('stratal:auth:guard')
+  AUTH_GUARD: Symbol.for('stratal:auth:guard'),
+  GATEWAY_MARKER: Symbol.for('stratal:gateway:marker'),
+  WS_ON_MESSAGE: Symbol.for('stratal:ws:on-message'),
+  WS_ON_CLOSE: Symbol.for('stratal:ws:on-close'),
+  WS_ON_ERROR: Symbol.for('stratal:ws:on-error'),
 } as const
 
 /**

--- a/packages/core/src/router/hono-app.ts
+++ b/packages/core/src/router/hono-app.ts
@@ -94,11 +94,11 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
    * Configure module middleware, OpenAPI endpoints, controller routes, and 404 handler.
    * Called once by Application.initialize().
    */
-  configure(
+  async configure(
     middlewareConfigs: MiddlewareConfigEntry[],
     controllers: Constructor<IController>[],
     versioningOptions?: VersioningOptions | null,
-  ): void {
+  ): Promise<void> {
     if (this.configured) throw new HonoAppAlreadyConfiguredError()
 
     // Module middleware
@@ -111,7 +111,7 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
 
     // Controller routes
     const routeRegistrationService = new RouteRegistrationService(this._logger, versioningOptions ?? null)
-    routeRegistrationService.configure(this, controllers)
+    await routeRegistrationService.configure(this, controllers)
 
     // 404 handler (must be last)
     this.notFound((c) => { throw new RouteNotFoundError(c.req.path, c.req.method) })

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -13,8 +13,8 @@ export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEME
 export { RouterContext } from './router-context'
 
 // Streaming types
+export type { SSEMessage, SSEStreamingApi } from 'hono/streaming'
 export type { StreamingApi } from 'hono/utils/stream'
-export type { SSEStreamingApi, SSEMessage } from 'hono/streaming'
 
 // HonoApp
 export { HonoApp } from './hono-app'

--- a/packages/core/src/router/router-context.ts
+++ b/packages/core/src/router/router-context.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
-import { stream as honoStream, streamText as honoStreamText, streamSSE as honoStreamSSE } from 'hono/streaming'
 import type { SSEStreamingApi } from 'hono/streaming'
+import { stream as honoStream, streamSSE as honoStreamSSE, streamText as honoStreamText } from 'hono/streaming'
 import type { ContentfulStatusCode, RedirectStatusCode } from 'hono/utils/http-status'
 import type { StreamingApi } from 'hono/utils/stream'
 import type { Container } from '../di/container'
@@ -8,7 +8,7 @@ import { RequestContainerNotInitializedError } from '../errors'
 import { ROUTER_CONTEXT_KEYS } from './constants'
 import type { RouterEnv } from './types'
 
-type ContextQueryResult<R extends Record<string, unknown> | undefined, K extends string | undefined> = K extends string ? string : R
+export type ContextQueryResult<R extends Record<string, unknown> | undefined, K extends string | undefined> = K extends string ? string : R extends undefined ? Record<string, unknown> : R
 
 /**
  * Router context wrapper with helper methods

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -1,4 +1,6 @@
-import type { Context } from 'hono'
+import type { Context, MiddlewareHandler } from 'hono'
+import { upgradeWebSocket } from 'hono/cloudflare-workers'
+import type { WSContext, WSEvents } from 'hono/ws'
 import { type Container, getMethodInjections } from '../../di'
 import {
   type Guard,
@@ -10,7 +12,9 @@ import type { OpenAPIHono } from '../../i18n/validation'
 import { createRoute } from '../../i18n/validation'
 import { type LoggerService } from '../../logger'
 import type { Constructor } from '../../types'
-import { DEFAULT_CONTENT_TYPE, HTTP_METHODS, METHOD_STATUS_CODES, SECURITY_SCHEMES } from '../constants'
+import { getWsOnCloseMethod, getWsOnErrorMethod, getWsOnMessageMethod, isGateway } from '../../websocket/decorators'
+import { GatewayContext } from '../../websocket/gateway-context'
+import { DEFAULT_CONTENT_TYPE, HTTP_METHODS, METHOD_STATUS_CODES, SECURITY_SCHEMES, VERSION_NEUTRAL } from '../constants'
 import type { IController } from '../controller'
 import {
   getControllerOptions,
@@ -18,7 +22,7 @@ import {
   getDecoratedMethods,
   getHttpDecoratedMethods,
   getHttpRouteMetadata,
-  getRouteConfig
+  getRouteConfig,
 } from '../decorators'
 import {
   ControllerMethodNotFoundError,
@@ -37,7 +41,6 @@ import type {
   SecuritySchemeRecord,
   VersioningOptions,
 } from '../types'
-import { VERSION_NEUTRAL } from '../constants'
 
 /**
  * Route registration service
@@ -83,12 +86,115 @@ export class RouteRegistrationService {
       return 0 // maintain relative order
     })
 
+    // Partition gateways from regular controllers
+    const gatewayClasses = sortedControllers.filter(c => isGateway(c))
+    const controllerClasses = sortedControllers.filter(c => !isGateway(c))
+
+    // Register WebSocket gateways
+    for (const GatewayClass of gatewayClasses) {
+      this.registerGateway(app, GatewayClass)
+    }
+
     // Register controllers
-    for (const ControllerClass of sortedControllers) {
+    for (const ControllerClass of controllerClasses) {
       this.registerController(app, ControllerClass)
     }
 
     this.logger.info('Controller registration complete')
+  }
+
+  /**
+   * Register a WebSocket gateway
+   * Applies versioning and guards, then registers an upgradeWebSocket handler
+   */
+  private registerGateway(app: OpenAPIHono<RouterEnv>, GatewayClass: Constructor<IController>): void {
+    const route = getControllerRoute(GatewayClass)
+
+    if (!route) {
+      throw new ControllerRegistrationError(
+        GatewayClass.name,
+        'Missing @Gateway decorator or route metadata'
+      )
+    }
+
+    const controllerOpts = getControllerOptions(GatewayClass)
+    const paths = this.versioningOptions
+      ? this.resolveVersionedPaths(route, controllerOpts)
+      : [route]
+
+    for (const fullPath of paths) {
+      this.registerGatewayRoute(app, GatewayClass, fullPath)
+    }
+  }
+
+  /**
+   * Register a single WebSocket gateway route
+   */
+  private registerGatewayRoute(
+    app: OpenAPIHono<RouterEnv>,
+    GatewayClass: Constructor<IController>,
+    fullPath: string
+  ): void {
+    // Collect class-level guards
+    const controllerGuards = getControllerGuards(GatewayClass)?.guards ?? []
+
+    const wsHandler: MiddlewareHandler<RouterEnv> = upgradeWebSocket((c) => {
+      const routerCtx = new RouterContext(c as Context<RouterEnv>)
+      const container = routerCtx.getContainer()
+      const gateway = container.resolve(GatewayClass)
+
+      // Cloudflare Workers doesn't support the `onOpen` WebSocket event;
+      // the upgrade callback itself serves as the open context.
+      const events: Omit<WSEvents, 'onOpen'> = {}
+
+      const onMsgMethod = getWsOnMessageMethod(GatewayClass)
+      if (onMsgMethod) {
+        events.onMessage = (evt: MessageEvent, ws: WSContext) => {
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
+          (gateway as Record<string, (...args: unknown[]) => void>)[onMsgMethod](evt, ctx);
+        }
+      }
+
+      const onCloseMethod = getWsOnCloseMethod(GatewayClass)
+      if (onCloseMethod) {
+        events.onClose = (evt: CloseEvent, ws: WSContext) => {
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
+          (gateway as Record<string, (...args: unknown[]) => void>)[onCloseMethod](evt, ctx)
+        }
+      }
+
+      const onErrMethod = getWsOnErrorMethod(GatewayClass)
+      if (onErrMethod) {
+        events.onError = (evt: Event, ws: WSContext) => {
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
+          (gateway as Record<string, (...args: unknown[]) => void>)[onErrMethod](evt, ctx)
+        }
+      }
+
+      return events
+    }) as MiddlewareHandler<RouterEnv>
+
+    this.logger.info('Registering WebSocket gateway', {
+      gateway: GatewayClass.name,
+      path: fullPath,
+    })
+
+    const handlers: MiddlewareHandler<RouterEnv>[] = []
+
+    if (controllerGuards.length > 0) {
+      this.logger.info('Gateway guards', {
+        gateway: GatewayClass.name,
+        path: fullPath,
+        guardCount: controllerGuards.length,
+      })
+      handlers.push(this.createGuardMiddleware(controllerGuards))
+    }
+
+    handlers.push(wsHandler)
+
+    // Type assertion needed because Hono's overloaded .get() signatures
+    // don't accept a spread of MiddlewareHandler[] alongside upgradeWebSocket's output type
+    app.get(fullPath, ...(handlers as [MiddlewareHandler<RouterEnv>]))
   }
 
   /**

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -1,5 +1,4 @@
 import type { Context, MiddlewareHandler } from 'hono'
-import { upgradeWebSocket } from 'hono/cloudflare-workers'
 import type { WSContext, WSEvents } from 'hono/ws'
 import { type Container, getMethodInjections } from '../../di'
 import {
@@ -67,10 +66,10 @@ export class RouteRegistrationService {
    * @param app - OpenAPIHono application instance
    * @param controllers - Array of controller classes from modules
    */
-  configure(
+  async configure(
     app: OpenAPIHono<RouterEnv>,
     controllers: Constructor<IController>[]
-  ): void {
+  ): Promise<void> {
     this.logger.info('Registering controllers', {
       controllerCount: controllers.length,
     })
@@ -86,17 +85,25 @@ export class RouteRegistrationService {
       return 0 // maintain relative order
     })
 
-    // Partition gateways from regular controllers
-    const gatewayClasses = sortedControllers.filter(c => isGateway(c))
-    const controllerClasses = sortedControllers.filter(c => !isGateway(c))
+    // Single-pass partition: gateways vs regular controllers
+    const gateways: Constructor<IController>[] = []
+    const regulars: Constructor<IController>[] = []
+
+    for (const c of sortedControllers) {
+      if (isGateway(c)) {
+        gateways.push(c)
+      } else {
+        regulars.push(c)
+      }
+    }
 
     // Register WebSocket gateways
-    for (const GatewayClass of gatewayClasses) {
-      this.registerGateway(app, GatewayClass)
+    for (const GatewayClass of gateways) {
+      await this.registerGateway(app, GatewayClass)
     }
 
     // Register controllers
-    for (const ControllerClass of controllerClasses) {
+    for (const ControllerClass of regulars) {
       this.registerController(app, ControllerClass)
     }
 
@@ -107,7 +114,7 @@ export class RouteRegistrationService {
    * Register a WebSocket gateway
    * Applies versioning and guards, then registers an upgradeWebSocket handler
    */
-  private registerGateway(app: OpenAPIHono<RouterEnv>, GatewayClass: Constructor<IController>): void {
+  private async registerGateway(app: OpenAPIHono<RouterEnv>, GatewayClass: Constructor<IController>): Promise<void> {
     const route = getControllerRoute(GatewayClass)
 
     if (!route) {
@@ -123,20 +130,28 @@ export class RouteRegistrationService {
       : [route]
 
     for (const fullPath of paths) {
-      this.registerGatewayRoute(app, GatewayClass, fullPath)
+      await this.registerGatewayRoute(app, GatewayClass, fullPath)
     }
   }
 
   /**
    * Register a single WebSocket gateway route
    */
-  private registerGatewayRoute(
+  private async registerGatewayRoute(
     app: OpenAPIHono<RouterEnv>,
     GatewayClass: Constructor<IController>,
     fullPath: string
-  ): void {
+  ): Promise<void> {
     // Collect class-level guards
     const controllerGuards = getControllerGuards(GatewayClass)?.guards ?? []
+
+    // Dynamic import: only load hono/cloudflare-workers when gateways exist
+    const { upgradeWebSocket } = await import('hono/cloudflare-workers')
+
+    // Cache WS metadata once at registration time (not per-connection)
+    const onMsgMethod = getWsOnMessageMethod(GatewayClass)
+    const onCloseMethod = getWsOnCloseMethod(GatewayClass)
+    const onErrMethod = getWsOnErrorMethod(GatewayClass)
 
     const wsHandler: MiddlewareHandler<RouterEnv> = upgradeWebSocket((c) => {
       const routerCtx = new RouterContext(c as Context<RouterEnv>)
@@ -147,7 +162,6 @@ export class RouteRegistrationService {
       // the upgrade callback itself serves as the open context.
       const events: Omit<WSEvents, 'onOpen'> = {}
 
-      const onMsgMethod = getWsOnMessageMethod(GatewayClass)
       if (onMsgMethod) {
         events.onMessage = (evt: MessageEvent, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
@@ -155,7 +169,6 @@ export class RouteRegistrationService {
         }
       }
 
-      const onCloseMethod = getWsOnCloseMethod(GatewayClass)
       if (onCloseMethod) {
         events.onClose = (evt: CloseEvent, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
@@ -163,7 +176,6 @@ export class RouteRegistrationService {
         }
       }
 
-      const onErrMethod = getWsOnErrorMethod(GatewayClass)
       if (onErrMethod) {
         events.onError = (evt: Event, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws);

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -164,22 +164,35 @@ export class RouteRegistrationService {
 
       if (onMsgMethod) {
         events.onMessage = (evt: MessageEvent, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
-          (gateway as Record<string, (...args: unknown[]) => void>)[onMsgMethod](evt, ctx);
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
+          c.executionCtx.waitUntil(
+            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onMsgMethod](evt, ctx)).catch((err: unknown) => {
+              this.logger.error('WebSocket onMessage handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
+              ws.close(1011, 'Internal Error')
+            })
+          )
         }
       }
 
       if (onCloseMethod) {
         events.onClose = (evt: CloseEvent, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
-          (gateway as Record<string, (...args: unknown[]) => void>)[onCloseMethod](evt, ctx)
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
+          c.executionCtx.waitUntil(
+            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onCloseMethod](evt, ctx)).catch((err: unknown) => {
+              this.logger.error('WebSocket onClose handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
+            })
+          )
         }
       }
 
       if (onErrMethod) {
         events.onError = (evt: Event, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws);
-          (gateway as Record<string, (...args: unknown[]) => void>)[onErrMethod](evt, ctx)
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
+          c.executionCtx.waitUntil(
+            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onErrMethod](evt, ctx)).catch((err: unknown) => {
+              this.logger.error('WebSocket onError handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
+            })
+          )
         }
       }
 

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -41,6 +41,14 @@ import type {
   VersioningOptions,
 } from '../types'
 
+const invokeHandler = (instance: Record<string, (...args: unknown[]) => unknown>, method: string, ...args: unknown[]): Promise<unknown> => {
+  try {
+    return Promise.resolve(instance[method](...args))
+  } catch (err: unknown) {
+    return Promise.reject(err as Error)
+  }
+}
+
 /**
  * Route registration service
  * Manages controller and route registration with OpenAPI support
@@ -166,7 +174,7 @@ export class RouteRegistrationService {
         events.onMessage = (evt: MessageEvent, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
           c.executionCtx.waitUntil(
-            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onMsgMethod](evt, ctx)).catch((err: unknown) => {
+            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onMsgMethod, evt, ctx).catch((err: unknown) => {
               this.logger.error('WebSocket onMessage handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
               ws.close(1011, 'Internal Error')
             })
@@ -178,7 +186,7 @@ export class RouteRegistrationService {
         events.onClose = (evt: CloseEvent, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
           c.executionCtx.waitUntil(
-            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onCloseMethod](evt, ctx)).catch((err: unknown) => {
+            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onCloseMethod, evt, ctx).catch((err: unknown) => {
               this.logger.error('WebSocket onClose handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
             })
           )
@@ -189,7 +197,7 @@ export class RouteRegistrationService {
         events.onError = (evt: Event, ws: WSContext) => {
           const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
           c.executionCtx.waitUntil(
-            Promise.resolve((gateway as Record<string, (...args: unknown[]) => unknown>)[onErrMethod](evt, ctx)).catch((err: unknown) => {
+            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onErrMethod, evt, ctx).catch((err: unknown) => {
               this.logger.error('WebSocket onError handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
             })
           )

--- a/packages/core/src/router/services/route-registration.service.ts
+++ b/packages/core/src/router/services/route-registration.service.ts
@@ -170,38 +170,29 @@ export class RouteRegistrationService {
       // the upgrade callback itself serves as the open context.
       const events: Omit<WSEvents, 'onOpen'> = {}
 
+      const bindWsHandler = (
+        method: string,
+        onCatch?: (err: unknown, ws: WSContext) => void
+      ) => {
+        return (evt: MessageEvent | CloseEvent | Event, ws: WSContext) => {
+          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
+          c.executionCtx.waitUntil(
+            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, method, evt, ctx).catch((err: unknown) => {
+              this.logger.error(`WebSocket ${method} handler error`, { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
+              onCatch?.(err, ws)
+            })
+          )
+        }
+      }
+
       if (onMsgMethod) {
-        events.onMessage = (evt: MessageEvent, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
-          c.executionCtx.waitUntil(
-            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onMsgMethod, evt, ctx).catch((err: unknown) => {
-              this.logger.error('WebSocket onMessage handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
-              ws.close(1011, 'Internal Error')
-            })
-          )
-        }
+        events.onMessage = bindWsHandler(onMsgMethod, (_err, ws) => ws.close(1011, 'Internal Error'))
       }
-
       if (onCloseMethod) {
-        events.onClose = (evt: CloseEvent, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
-          c.executionCtx.waitUntil(
-            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onCloseMethod, evt, ctx).catch((err: unknown) => {
-              this.logger.error('WebSocket onClose handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
-            })
-          )
-        }
+        events.onClose = bindWsHandler(onCloseMethod)
       }
-
       if (onErrMethod) {
-        events.onError = (evt: Event, ws: WSContext) => {
-          const ctx = new GatewayContext(c as Context<RouterEnv>, ws)
-          c.executionCtx.waitUntil(
-            invokeHandler(gateway as Record<string, (...args: unknown[]) => unknown>, onErrMethod, evt, ctx).catch((err: unknown) => {
-              this.logger.error('WebSocket onError handler error', { gateway: GatewayClass.name, error: err instanceof Error ? err.message : String(err) })
-            })
-          )
-        }
+        events.onError = bindWsHandler(onErrMethod)
       }
 
       return events

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -1,6 +1,6 @@
-import type { ZodObject, ZodPipe, ZodType, RouteConfig as OpenAPIRouteConfig } from '../i18n/validation'
-import { type StratalEnv } from '../env'
 import type { Container } from '../di'
+import { type StratalEnv } from '../env'
+import type { RouteConfig as OpenAPIRouteConfig, ZodObject, ZodPipe, ZodType } from '../i18n/validation'
 import { type HTTP_METHODS, type ROUTER_CONTEXT_KEYS, type SECURITY_SCHEMES, type VERSION_NEUTRAL } from './constants'
 
 /**

--- a/packages/core/src/websocket/__tests__/websocket.spec.ts
+++ b/packages/core/src/websocket/__tests__/websocket.spec.ts
@@ -1,0 +1,248 @@
+import { createMock } from '@stratal/testing/mocks'
+import type { Context } from 'hono'
+import type { WSContext } from 'hono/ws'
+import 'reflect-metadata'
+import { describe, expect, it, vi } from 'vitest'
+import { VERSION_NEUTRAL } from '../../router/constants'
+import { Controller, getControllerOptions, getControllerRoute } from '../../router/decorators/controller.decorator'
+import type { RouterEnv } from '../../router/types'
+import { Gateway, isGateway } from '../decorators/gateway.decorator'
+import {
+  OnClose,
+  OnError,
+  OnMessage,
+  getWsOnCloseMethod,
+  getWsOnErrorMethod,
+  getWsOnMessageMethod,
+} from '../decorators/ws-event.decorator'
+import { WebSocketBodyNotAvailableError } from '../errors/websocket-body-not-available.error'
+import { GatewayContext } from '../gateway-context'
+
+describe('WebSocket Support', () => {
+  describe('@Gateway decorator', () => {
+    it('should store route retrievable via getControllerRoute()', () => {
+      @Gateway('/ws/chat')
+      class TestGateway { }
+
+      expect(getControllerRoute(TestGateway)).toBe('/ws/chat')
+    })
+
+    it('should mark class as a gateway', () => {
+      @Gateway('/ws/test')
+      class TestGateway { }
+
+      expect(isGateway(TestGateway)).toBe(true)
+    })
+
+    it('should store version options retrievable via getControllerOptions()', () => {
+      @Gateway('/ws/chat', { version: '1' })
+      class TestGateway { }
+
+      expect(getControllerOptions(TestGateway)).toEqual({ version: '1' })
+    })
+
+    it('should support array versions', () => {
+      @Gateway('/ws/chat', { version: ['1', '2'] })
+      class TestGateway { }
+
+      expect(getControllerOptions(TestGateway)).toEqual({ version: ['1', '2'] })
+    })
+
+    it('should support VERSION_NEUTRAL', () => {
+      @Gateway('/ws/chat', { version: VERSION_NEUTRAL })
+      class TestGateway { }
+
+      expect(getControllerOptions(TestGateway)).toEqual({ version: VERSION_NEUTRAL })
+    })
+
+    it('should not store options when omitted', () => {
+      @Gateway('/ws/chat')
+      class TestGateway { }
+
+      expect(getControllerOptions(TestGateway)).toBeUndefined()
+    })
+  })
+
+  describe('isGateway()', () => {
+    it('should return true for gateway classes', () => {
+      @Gateway('/ws/test')
+      class TestGateway { }
+
+      expect(isGateway(TestGateway)).toBe(true)
+    })
+
+    it('should return false for controller classes', () => {
+      @Controller('/api/test')
+      class TestController { }
+
+      expect(isGateway(TestController)).toBe(false)
+    })
+
+    it('should return false for plain classes', () => {
+      class PlainClass { }
+
+      expect(isGateway(PlainClass)).toBe(false)
+    })
+  })
+
+  describe('WebSocket event decorators', () => {
+    it('@OnMessage() should store method name', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        @OnMessage()
+        handleMessage() { /* noop */ }
+      }
+
+      expect(getWsOnMessageMethod(TestGateway)).toBe('handleMessage')
+    })
+
+    it('@OnClose() should store method name', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        @OnClose()
+        handleClose() { /* noop */ }
+      }
+
+      expect(getWsOnCloseMethod(TestGateway)).toBe('handleClose')
+    })
+
+    it('@OnError() should store method name', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        @OnError()
+        handleError() { /* noop */ }
+      }
+
+      expect(getWsOnErrorMethod(TestGateway)).toBe('handleError')
+    })
+
+    it('should support all three decorators on one gateway', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        @OnMessage()
+        onMsg() { /* noop */ }
+
+        @OnClose()
+        onCls() { /* noop */ }
+
+        @OnError()
+        onErr() { /* noop */ }
+      }
+
+      expect(getWsOnMessageMethod(TestGateway)).toBe('onMsg')
+      expect(getWsOnCloseMethod(TestGateway)).toBe('onCls')
+      expect(getWsOnErrorMethod(TestGateway)).toBe('onErr')
+    })
+
+    it('should return undefined when no decorator is applied', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        someMethod() { /* noop */ }
+      }
+
+      expect(getWsOnMessageMethod(TestGateway)).toBeUndefined()
+      expect(getWsOnCloseMethod(TestGateway)).toBeUndefined()
+      expect(getWsOnErrorMethod(TestGateway)).toBeUndefined()
+    })
+
+    it('last decorator wins when multiple methods use the same event', () => {
+      @Gateway('/ws/test')
+      class TestGateway {
+        @OnMessage()
+        firstHandler() { /* noop */ }
+
+        @OnMessage()
+        secondHandler() { /* noop */ }
+      }
+
+      expect(getWsOnMessageMethod(TestGateway)).toBe('secondHandler')
+    })
+  })
+
+  describe('GatewayContext', () => {
+    const mockHonoContext = createMock<Context<RouterEnv>>({
+      get: vi.fn((key: string) => {
+        if (key === 'requestContainer') return { resolve: vi.fn() }
+        if (key === 'locale') return 'en'
+        return undefined
+      }),
+      req: {
+        header: vi.fn().mockReturnValue('Bearer token'),
+        param: vi.fn((key?: string) => {
+          const params: Record<string, string> = { id: '42', room: 'general' }
+          return key ? params[key] : params
+        }),
+        query: vi.fn((key?: string) => {
+          const queries: Record<string, string> = { page: '1', limit: '10' }
+          return key ? queries[key] : queries
+        }),
+      },
+    })
+
+    const mockWsContext = createMock<WSContext>({
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+    })
+
+    it('should extend RouterContext', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.getLocale()).toBe('en')
+      expect(ctx.header('Authorization')).toBe('Bearer token')
+    })
+
+    it('should expose ws property', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.ws).toBe(mockWsContext)
+    })
+
+    it('send() should delegate to ws.send()', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      ctx.send('hello')
+      expect(mockWsContext.send).toHaveBeenCalledWith('hello')
+    })
+
+    it('close() should delegate to ws.close()', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      ctx.close(1000, 'normal')
+      expect(mockWsContext.close).toHaveBeenCalledWith(1000, 'normal')
+    })
+
+    it('readyState should delegate to ws.readyState', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.readyState).toBe(1)
+    })
+
+    it('param() should use raw c.req.param() instead of c.req.valid()', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.param('id')).toBe('42')
+      expect(mockHonoContext.req.param).toHaveBeenCalledWith('id')
+    })
+
+    it('query() with key should use raw c.req.query(key)', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.query('page')).toBe('1')
+      expect(mockHonoContext.req.query).toHaveBeenCalledWith('page')
+    })
+
+    it('query() without key should return all query params', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(ctx.query()).toEqual({ page: '1', limit: '10' })
+      expect(mockHonoContext.req.query).toHaveBeenCalledWith()
+    })
+
+    it('body() should throw WebSocketBodyNotAvailableError', () => {
+      const ctx = new GatewayContext(mockHonoContext, mockWsContext)
+
+      expect(() => ctx.body()).toThrow(WebSocketBodyNotAvailableError)
+    })
+  })
+})

--- a/packages/core/src/websocket/__tests__/websocket.spec.ts
+++ b/packages/core/src/websocket/__tests__/websocket.spec.ts
@@ -16,6 +16,7 @@ import {
   getWsOnMessageMethod,
 } from '../decorators/ws-event.decorator'
 import { WebSocketBodyNotAvailableError } from '../errors/websocket-body-not-available.error'
+import { WebSocketDuplicateEventHandlerError } from '../errors/websocket-duplicate-event-handler.error'
 import { GatewayContext } from '../gateway-context'
 
 describe('WebSocket Support', () => {
@@ -145,17 +146,17 @@ describe('WebSocket Support', () => {
       expect(getWsOnErrorMethod(TestGateway)).toBeUndefined()
     })
 
-    it('last decorator wins when multiple methods use the same event', () => {
-      @Gateway('/ws/test')
-      class TestGateway {
-        @OnMessage()
-        firstHandler() { /* noop */ }
+    it('should throw when multiple methods use the same event decorator', () => {
+      expect(() => {
+        @Gateway('/ws/test')
+        class _TestGateway {
+          @OnMessage()
+          firstHandler() { /* noop */ }
 
-        @OnMessage()
-        secondHandler() { /* noop */ }
-      }
-
-      expect(getWsOnMessageMethod(TestGateway)).toBe('secondHandler')
+          @OnMessage()
+          secondHandler() { /* noop */ }
+        }
+      }).toThrow(WebSocketDuplicateEventHandlerError)
     })
   })
 

--- a/packages/core/src/websocket/decorators/gateway.decorator.ts
+++ b/packages/core/src/websocket/decorators/gateway.decorator.ts
@@ -1,0 +1,59 @@
+import { Transient } from '../../di/decorators'
+import { ROUTE_METADATA_KEYS } from '../../router/constants'
+import { type Constructor } from '../../types'
+import type { GatewayOptions } from '../../websocket/types'
+
+const CONTROLLER_ROUTE_KEY = ROUTE_METADATA_KEYS.CONTROLLER_ROUTE
+const CONTROLLER_OPTIONS_KEY = ROUTE_METADATA_KEYS.CONTROLLER_OPTIONS
+const GATEWAY_MARKER_KEY = ROUTE_METADATA_KEYS.GATEWAY_MARKER
+
+/**
+ * Gateway decorator for WebSocket route registration
+ *
+ * Marks a class as a WebSocket gateway and stores route metadata.
+ * Reuses the same metadata key as @Controller for middleware compatibility —
+ * `getControllerRoute()`, `forRoutes()`, and the entire middleware system work
+ * with zero changes.
+ *
+ * @param route - WebSocket route path (e.g., '/ws/chat')
+ *
+ * @example
+ * ```typescript
+ * import { type GatewayContext, Gateway, OnMessage, OnClose } from 'stratal/websocket'
+ *
+ * @Gateway('/ws/chat')
+ * class ChatGateway {
+ *   @OnMessage()
+ *   handleMessage(evt: MessageEvent, ctx: GatewayContext) {
+ *     ctx.send('ack')
+ *   }
+ *
+ *   @OnClose()
+ *   handleClose(evt: CloseEvent, ctx: GatewayContext) {
+ *     console.log('closed')
+ *   }
+ * }
+ * ```
+ */
+export function Gateway(route: string, options?: GatewayOptions) {
+  return function <T extends Constructor>(target: T) {
+    Transient()(target)
+    Reflect.defineMetadata(CONTROLLER_ROUTE_KEY, route, target)
+    Reflect.defineMetadata(GATEWAY_MARKER_KEY, true, target)
+    if (options) {
+      Reflect.defineMetadata(CONTROLLER_OPTIONS_KEY, options, target)
+    }
+    return target
+  }
+}
+
+/**
+ * Check if a class is a WebSocket gateway
+ *
+ * @param target - Class constructor or instance
+ * @returns true if the class is decorated with @Gateway
+ */
+export function isGateway(target: object): boolean {
+  const metadataTarget = typeof target === 'function' ? target : (target as { constructor: object }).constructor
+  return Reflect.getMetadata(GATEWAY_MARKER_KEY, metadataTarget) === true
+}

--- a/packages/core/src/websocket/decorators/index.ts
+++ b/packages/core/src/websocket/decorators/index.ts
@@ -1,0 +1,3 @@
+export { Gateway, isGateway } from './gateway.decorator'
+export { getWsOnCloseMethod, getWsOnErrorMethod, getWsOnMessageMethod, OnClose, OnError, OnMessage } from './ws-event.decorator'
+

--- a/packages/core/src/websocket/decorators/ws-event.decorator.ts
+++ b/packages/core/src/websocket/decorators/ws-event.decorator.ts
@@ -1,0 +1,89 @@
+import { ROUTE_METADATA_KEYS } from '../../router/constants'
+import type { Constructor } from '../../types'
+
+const WS_ON_MESSAGE_KEY = ROUTE_METADATA_KEYS.WS_ON_MESSAGE
+const WS_ON_CLOSE_KEY = ROUTE_METADATA_KEYS.WS_ON_CLOSE
+const WS_ON_ERROR_KEY = ROUTE_METADATA_KEYS.WS_ON_ERROR
+
+/**
+ * Marks a method as the WebSocket message handler
+ *
+ * @example
+ * ```typescript
+ * @Gateway('/ws/chat')
+ * class ChatGateway {
+ *   @OnMessage()
+ *   handleMessage(evt: MessageEvent, ctx: GatewayContext) {
+ *     ctx.send(evt.data)
+ *   }
+ * }
+ * ```
+ */
+export function OnMessage(): MethodDecorator {
+  // `_target` is the class prototype (method decorator convention).
+  // The getter functions below read from `target.prototype` symmetrically.
+  return (_target: object, propertyKey: string | symbol) => {
+    Reflect.defineMetadata(WS_ON_MESSAGE_KEY, propertyKey as string, _target)
+  }
+}
+
+/**
+ * Marks a method as the WebSocket close handler
+ *
+ * @example
+ * ```typescript
+ * @Gateway('/ws/chat')
+ * class ChatGateway {
+ *   @OnClose()
+ *   handleClose(evt: CloseEvent, ctx: GatewayContext) {
+ *     console.log('closed')
+ *   }
+ * }
+ * ```
+ */
+export function OnClose(): MethodDecorator {
+  return (_target: object, propertyKey: string | symbol) => {
+    Reflect.defineMetadata(WS_ON_CLOSE_KEY, propertyKey as string, _target)
+  }
+}
+
+/**
+ * Marks a method as the WebSocket error handler
+ *
+ * @example
+ * ```typescript
+ * @Gateway('/ws/chat')
+ * class ChatGateway {
+ *   @OnError()
+ *   handleError(evt: Event, ctx: GatewayContext) {
+ *     console.error('WebSocket error', evt)
+ *   }
+ * }
+ * ```
+ */
+export function OnError(): MethodDecorator {
+  return (_target: object, propertyKey: string | symbol) => {
+    Reflect.defineMetadata(WS_ON_ERROR_KEY, propertyKey as string, _target)
+  }
+}
+
+/**
+ * Get the method name decorated with @OnMessage
+ */
+export function getWsOnMessageMethod(target: Constructor): string | undefined {
+  return Reflect.getMetadata(WS_ON_MESSAGE_KEY, target.prototype as object) as string | undefined
+}
+
+/**
+ * Get the method name decorated with @OnClose
+ */
+export function getWsOnCloseMethod(target: Constructor): string | undefined {
+  return Reflect.getMetadata(WS_ON_CLOSE_KEY, target.prototype as object) as string | undefined
+}
+
+/**
+ * Get the method name decorated with @OnError
+ */
+export function getWsOnErrorMethod(target: Constructor): string | undefined {
+  return Reflect.getMetadata(WS_ON_ERROR_KEY, target.prototype as object) as string | undefined
+}

--- a/packages/core/src/websocket/decorators/ws-event.decorator.ts
+++ b/packages/core/src/websocket/decorators/ws-event.decorator.ts
@@ -1,9 +1,22 @@
 import { ROUTE_METADATA_KEYS } from '../../router/constants'
 import type { Constructor } from '../../types'
+import { WebSocketDuplicateEventHandlerError } from '../errors/websocket-duplicate-event-handler.error'
 
 const WS_ON_MESSAGE_KEY = ROUTE_METADATA_KEYS.WS_ON_MESSAGE
 const WS_ON_CLOSE_KEY = ROUTE_METADATA_KEYS.WS_ON_CLOSE
 const WS_ON_ERROR_KEY = ROUTE_METADATA_KEYS.WS_ON_ERROR
+
+/**
+ * Define a single-handler metadata key on the prototype.
+ * Throws if a different method already owns this key (prevents silent override).
+ */
+function defineSingleHandlerMetadata(key: string | symbol, propertyKey: string | symbol, target: object, decoratorName: string): void {
+  const existing = Reflect.getMetadata(key, target) as string | symbol | undefined
+  if (existing !== undefined && existing !== propertyKey) {
+    throw new WebSocketDuplicateEventHandlerError(decoratorName, String(existing))
+  }
+  Reflect.defineMetadata(key, propertyKey, target)
+}
 
 /**
  * Marks a method as the WebSocket message handler
@@ -23,7 +36,7 @@ export function OnMessage(): MethodDecorator {
   // `_target` is the class prototype (method decorator convention).
   // The getter functions below read from `target.prototype` symmetrically.
   return (_target: object, propertyKey: string | symbol) => {
-    Reflect.defineMetadata(WS_ON_MESSAGE_KEY, propertyKey as string, _target)
+    defineSingleHandlerMetadata(WS_ON_MESSAGE_KEY, propertyKey, _target, 'OnMessage')
   }
 }
 
@@ -43,7 +56,7 @@ export function OnMessage(): MethodDecorator {
  */
 export function OnClose(): MethodDecorator {
   return (_target: object, propertyKey: string | symbol) => {
-    Reflect.defineMetadata(WS_ON_CLOSE_KEY, propertyKey as string, _target)
+    defineSingleHandlerMetadata(WS_ON_CLOSE_KEY, propertyKey, _target, 'OnClose')
   }
 }
 
@@ -63,7 +76,7 @@ export function OnClose(): MethodDecorator {
  */
 export function OnError(): MethodDecorator {
   return (_target: object, propertyKey: string | symbol) => {
-    Reflect.defineMetadata(WS_ON_ERROR_KEY, propertyKey as string, _target)
+    defineSingleHandlerMetadata(WS_ON_ERROR_KEY, propertyKey, _target, 'OnError')
   }
 }
 

--- a/packages/core/src/websocket/errors/websocket-body-not-available.error.ts
+++ b/packages/core/src/websocket/errors/websocket-body-not-available.error.ts
@@ -1,0 +1,10 @@
+import { ApplicationError, ERROR_CODES } from '../../errors'
+
+export class WebSocketBodyNotAvailableError extends ApplicationError {
+  constructor() {
+    super(
+      'errors.websocketBodyNotAvailable',
+      ERROR_CODES.SYSTEM.WEBSOCKET_BODY_NOT_AVAILABLE
+    )
+  }
+}

--- a/packages/core/src/websocket/errors/websocket-duplicate-event-handler.error.ts
+++ b/packages/core/src/websocket/errors/websocket-duplicate-event-handler.error.ts
@@ -1,0 +1,11 @@
+import { ApplicationError, ERROR_CODES } from '../../errors'
+
+export class WebSocketDuplicateEventHandlerError extends ApplicationError {
+  constructor(decorator: string, existingMethod: string) {
+    super(
+      'errors.websocketDuplicateEventHandler',
+      ERROR_CODES.SYSTEM.WEBSOCKET_DUPLICATE_EVENT_HANDLER,
+      { decorator, existingMethod }
+    )
+  }
+}

--- a/packages/core/src/websocket/gateway-context.ts
+++ b/packages/core/src/websocket/gateway-context.ts
@@ -1,0 +1,74 @@
+import type { Context } from 'hono'
+import type { WSContext, WSReadyState } from 'hono/ws'
+import type { ContextQueryResult } from '../router/router-context'
+import { RouterContext } from '../router/router-context'
+import type { RouterEnv } from '../router/types'
+import { WebSocketBodyNotAvailableError } from './errors/websocket-body-not-available.error'
+
+/**
+ * WebSocket gateway context
+ *
+ * Extends RouterContext with WebSocket-specific methods.
+ * Inherits `getContainer()`, `param()`, `query()`, `header()`, `getLocale()`
+ * from RouterContext. HTTP response methods (`json()`, `redirect()`, etc.) are
+ * inherited but harmless post-upgrade.
+ *
+ * @example
+ * ```typescript
+ * @OnMessage()
+ * handleMessage(evt: MessageEvent, ctx: GatewayContext) {
+ *   ctx.send('ack')           // convenience method
+ *   ctx.header('Authorization') // upgrade request headers
+ * }
+ * ```
+ */
+export class GatewayContext extends RouterContext {
+  constructor(c: Context<RouterEnv>, public readonly ws: WSContext) {
+    super(c)
+  }
+
+  /** Send data through the WebSocket connection */
+  send(data: string | ArrayBuffer | Uint8Array<ArrayBuffer>): void {
+    this.ws.send(data)
+  }
+
+  /** Close the WebSocket connection */
+  close(code?: number, reason?: string): void {
+    this.ws.close(code, reason)
+  }
+
+  /** Current WebSocket ready state */
+  get readyState(): WSReadyState {
+    return this.ws.readyState
+  }
+
+  /**
+   * Get route parameter value from the raw request (no OpenAPI validation)
+   *
+   * @param key - Parameter name (e.g., 'id' for /ws/chat/:id)
+   */
+  override param(key: string): string {
+    return this.c.req.param(key)!
+  }
+
+  /**
+   * Get query parameter value from the raw request (no OpenAPI validation)
+   *
+   * @param key - Query parameter name
+   */
+  override query<R extends Record<string, unknown> | undefined = undefined, K extends string | undefined = undefined>(key?: K): ContextQueryResult<R, K> {
+    if (key) {
+      return this.c.req.query(key) as ContextQueryResult<R, K>
+    }
+    return this.c.req.query() as ContextQueryResult<R, K>
+  }
+
+  /**
+   * Request body is not available in WebSocket gateways
+   *
+   * @throws WebSocketBodyNotAvailableError always — WebSocket upgrade requests do not have a body
+   */
+  override body<T>(): Promise<T> {
+    throw new WebSocketBodyNotAvailableError()
+  }
+}

--- a/packages/core/src/websocket/index.ts
+++ b/packages/core/src/websocket/index.ts
@@ -1,5 +1,7 @@
 export type { WSContext, WSEvents, WSMessageReceive, WSReadyState } from 'hono/ws'
+export { Gateway, isGateway, OnMessage, OnClose, OnError, getWsOnMessageMethod, getWsOnCloseMethod, getWsOnErrorMethod } from './decorators'
 export { WebSocketBodyNotAvailableError } from './errors/websocket-body-not-available.error'
+export { WebSocketDuplicateEventHandlerError } from './errors/websocket-duplicate-event-handler.error'
 export { GatewayContext } from './gateway-context'
 export type { GatewayOptions } from './types'
 

--- a/packages/core/src/websocket/index.ts
+++ b/packages/core/src/websocket/index.ts
@@ -1,0 +1,5 @@
+export type { WSContext, WSEvents, WSMessageReceive, WSReadyState } from 'hono/ws'
+export { WebSocketBodyNotAvailableError } from './errors/websocket-body-not-available.error'
+export { GatewayContext } from './gateway-context'
+export type { GatewayOptions } from './types'
+

--- a/packages/core/src/websocket/types.ts
+++ b/packages/core/src/websocket/types.ts
@@ -1,0 +1,7 @@
+import { type ControllerOptions } from "../router/types";
+
+/**
+ * Gateway options for @Gateway() decorator
+ * Subset of ControllerOptions relevant to WebSocket gateways (no OpenAPI-specific fields)
+ */
+export type GatewayOptions = Pick<ControllerOptions, 'version'>

--- a/packages/core/test/fixtures/gateway.controller.ts
+++ b/packages/core/test/fixtures/gateway.controller.ts
@@ -1,0 +1,27 @@
+import { Module } from '../../src/module/module.decorator'
+import { Gateway } from '../../src/websocket/decorators/gateway.decorator'
+import { OnClose, OnError, OnMessage } from '../../src/websocket/decorators/ws-event.decorator'
+import type { GatewayContext } from '../../src/websocket/gateway-context'
+
+@Gateway('/ws/chat')
+export class ChatGateway {
+  @OnMessage()
+  handleMessage(evt: MessageEvent, ctx: GatewayContext) {
+    ctx.send(`echo:${evt.data as string}`)
+  }
+
+  @OnClose()
+  handleClose(_evt: CloseEvent, _ctx: GatewayContext) {
+    // noop
+  }
+
+  @OnError()
+  handleError(_evt: Event, _ctx: GatewayContext) {
+    // noop
+  }
+}
+
+@Module({
+  controllers: [ChatGateway],
+})
+export class GatewayAppModule { }

--- a/packages/core/test/integration/streaming.spec.ts
+++ b/packages/core/test/integration/streaming.spec.ts
@@ -57,25 +57,22 @@ describe('Streaming', () => {
 
   describe('streamSSE()', () => {
     it('should set Content-Encoding to Identity', async () => {
-      const response = await module.http.get('/streaming/sse').send()
-
-      response.assertHeader('Content-Encoding', 'Identity')
+      const sse = await module.sse('/streaming/sse').connect()
+      expect(sse.raw.headers.get('Content-Encoding')).toBe('Identity')
+      await sse.waitForEnd()
     })
 
-    it('should produce SSE-formatted output', async () => {
-      const response = await module.http.get('/streaming/sse').send()
-
-      const text = await response.raw.text()
-      expect(text.includes('event: message')).toBe(true)
-      expect(text.includes('data: hello')).toBe(true)
-      expect(text.includes('id: 1')).toBe(true)
+    it('should produce SSE-formatted events', async () => {
+      const sse = await module.sse('/streaming/sse').connect()
+      await sse.assertEvent({ event: 'message', data: 'hello', id: '1' })
+      await sse.waitForEnd()
     })
 
     it('should set Content-Type to text/event-stream', async () => {
-      const response = await module.http.get('/streaming/sse').send()
-
-      const contentType = response.headers.get('Content-Type') ?? ''
+      const sse = await module.sse('/streaming/sse').connect()
+      const contentType = sse.raw.headers.get('Content-Type') ?? ''
       expect(contentType.includes('text/event-stream')).toBe(true)
+      await sse.waitForEnd()
     })
   })
 })

--- a/packages/core/test/integration/websocket.spec.ts
+++ b/packages/core/test/integration/websocket.spec.ts
@@ -1,0 +1,41 @@
+import { Test, type TestingModule } from '@stratal/testing'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { GatewayAppModule } from '../fixtures/gateway.controller'
+
+describe('WebSocket Gateway Integration', () => {
+  let module: TestingModule
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [GatewayAppModule],
+    }).compile()
+  })
+
+  afterAll(async () => {
+    await module.close()
+  })
+
+  it('should register gateway as a GET route', () => {
+    const routes = module.application.hono.routes
+    const wsRoute = routes.find(r => r.path === '/ws/chat' && r.method === 'GET')
+    expect(wsRoute).toBeDefined()
+  })
+
+  it('should not register gateway as a non-GET route', () => {
+    const routes = module.application.hono.routes
+    const nonGetRoutes = routes.filter(r => r.path === '/ws/chat' && r.method !== 'GET' && r.method !== 'ALL')
+    expect(nonGetRoutes).toHaveLength(0)
+  })
+
+  it('should respond to WebSocket upgrade requests', async () => {
+    const ws = await module.ws('/ws/chat').connect()
+    ws.close()
+  })
+
+  it('should echo messages back through the gateway', async () => {
+    const ws = await module.ws('/ws/chat').connect()
+    ws.send('hello')
+    await ws.assertMessage('echo:hello')
+    ws.close()
+  })
+})

--- a/packages/testing/src/core/sse/index.ts
+++ b/packages/testing/src/core/sse/index.ts
@@ -1,0 +1,2 @@
+export { TestSseRequest } from './test-sse-request'
+export { TestSseConnection, type TestSseEvent } from './test-sse-connection'

--- a/packages/testing/src/core/sse/test-sse-connection.ts
+++ b/packages/testing/src/core/sse/test-sse-connection.ts
@@ -45,16 +45,18 @@ export class TestSseConnection {
 		}
 
 		return new Promise<TestSseEvent>((resolve, reject) => {
+			const waiter = (event: TestSseEvent) => {
+				clearTimeout(timer)
+				resolve(event)
+			}
+
 			const timer = setTimeout(() => {
-				const index = this.eventWaiters.indexOf(resolve)
+				const index = this.eventWaiters.indexOf(waiter)
 				if (index !== -1) this.eventWaiters.splice(index, 1)
 				reject(new Error(`SSE: no event received within ${timeout}ms`))
 			}, timeout)
 
-			this.eventWaiters.push((event) => {
-				clearTimeout(timer)
-				resolve(event)
-			})
+			this.eventWaiters.push(waiter)
 		})
 	}
 
@@ -65,14 +67,18 @@ export class TestSseConnection {
 		if (this.streamEnded) return
 
 		return new Promise<void>((resolve, reject) => {
+			const waiter = () => {
+				clearTimeout(timer)
+				resolve()
+			}
+
 			const timer = setTimeout(() => {
+				const index = this.endWaiters.indexOf(waiter)
+				if (index !== -1) this.endWaiters.splice(index, 1)
 				reject(new Error(`SSE: stream did not end within ${timeout}ms`))
 			}, timeout)
 
-			this.endWaiters.push(() => {
-				clearTimeout(timer)
-				resolve()
-			})
+			this.endWaiters.push(waiter)
 		})
 	}
 
@@ -87,13 +93,6 @@ export class TestSseConnection {
 		}
 
 		return new Promise<TestSseEvent[]>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				reject(new Error(`SSE: stream did not end within ${timeout}ms`))
-			}, timeout)
-
-			// Drain any queued events first
-			events.push(...this.eventQueue.splice(0))
-
 			// Listen for new events until stream ends
 			const originalDispatch = this.dispatchEvent.bind(this)
 			this.dispatchEvent = (event: TestSseEvent) => {
@@ -101,11 +100,23 @@ export class TestSseConnection {
 				originalDispatch(event)
 			}
 
-			this.endWaiters.push(() => {
+			const endWaiter = () => {
 				clearTimeout(timer)
 				this.dispatchEvent = originalDispatch
 				resolve(events)
-			})
+			}
+
+			const timer = setTimeout(() => {
+				this.dispatchEvent = originalDispatch
+				const index = this.endWaiters.indexOf(endWaiter)
+				if (index !== -1) this.endWaiters.splice(index, 1)
+				reject(new Error(`SSE: stream did not end within ${timeout}ms`))
+			}, timeout)
+
+			// Drain any queued events first
+			events.push(...this.eventQueue.splice(0))
+
+			this.endWaiters.push(endWaiter)
 		})
 	}
 

--- a/packages/testing/src/core/sse/test-sse-connection.ts
+++ b/packages/testing/src/core/sse/test-sse-connection.ts
@@ -1,0 +1,252 @@
+import { expect } from "vitest"
+
+/**
+ * Represents a parsed SSE event
+ */
+export interface TestSseEvent {
+	data: string
+	event?: string
+	id?: string
+	retry?: number
+}
+
+/**
+ * TestSseConnection
+ *
+ * Live SSE connection wrapper with assertion helpers for testing.
+ *
+ * @example
+ * ```typescript
+ * const sse = await module.sse('/streaming/sse').connect()
+ * await sse.assertEvent({ event: 'message', data: 'hello', id: '1' })
+ * await sse.waitForEnd()
+ * ```
+ */
+export class TestSseConnection {
+	private readonly eventQueue: TestSseEvent[] = []
+	private eventWaiters: ((event: TestSseEvent) => void)[] = []
+	private streamEnded = false
+	private endWaiters: (() => void)[] = []
+
+	constructor(private readonly response: Response) {
+		this.startReading()
+	}
+
+	/**
+	 * Wait for the next SSE event
+	 */
+	async waitForEvent(timeout = 5000): Promise<TestSseEvent> {
+		if (this.eventQueue.length > 0) {
+			return this.eventQueue.shift()!
+		}
+
+		if (this.streamEnded) {
+			throw new Error('SSE: stream has ended, no more events')
+		}
+
+		return new Promise<TestSseEvent>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				const index = this.eventWaiters.indexOf(resolve)
+				if (index !== -1) this.eventWaiters.splice(index, 1)
+				reject(new Error(`SSE: no event received within ${timeout}ms`))
+			}, timeout)
+
+			this.eventWaiters.push((event) => {
+				clearTimeout(timer)
+				resolve(event)
+			})
+		})
+	}
+
+	/**
+	 * Wait for the stream to end
+	 */
+	async waitForEnd(timeout = 5000): Promise<void> {
+		if (this.streamEnded) return
+
+		return new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				reject(new Error(`SSE: stream did not end within ${timeout}ms`))
+			}, timeout)
+
+			this.endWaiters.push(() => {
+				clearTimeout(timer)
+				resolve()
+			})
+		})
+	}
+
+	/**
+	 * Collect all remaining events until the stream ends
+	 */
+	async collectEvents(timeout = 5000): Promise<TestSseEvent[]> {
+		const events: TestSseEvent[] = []
+
+		if (this.streamEnded) {
+			return [...this.eventQueue.splice(0)]
+		}
+
+		return new Promise<TestSseEvent[]>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				reject(new Error(`SSE: stream did not end within ${timeout}ms`))
+			}, timeout)
+
+			// Drain any queued events first
+			events.push(...this.eventQueue.splice(0))
+
+			// Listen for new events until stream ends
+			const originalDispatch = this.dispatchEvent.bind(this)
+			this.dispatchEvent = (event: TestSseEvent) => {
+				events.push(event)
+				originalDispatch(event)
+			}
+
+			this.endWaiters.push(() => {
+				clearTimeout(timer)
+				this.dispatchEvent = originalDispatch
+				resolve(events)
+			})
+		})
+	}
+
+	/**
+	 * Assert that the next event matches the expected partial shape
+	 */
+	async assertEvent(expected: Partial<TestSseEvent>, timeout = 5000): Promise<void> {
+		const event = await this.waitForEvent(timeout)
+		expect(event).toMatchObject(expected)
+	}
+
+	/**
+	 * Assert that the next event's data matches the expected string
+	 */
+	async assertEventData(expected: string, timeout = 5000): Promise<void> {
+		const event = await this.waitForEvent(timeout)
+		expect(event.data, `Expected SSE data "${expected}", got "${event.data}"`).toBe(expected)
+	}
+
+	/**
+	 * Assert that the next event's data is JSON matching the expected value
+	 */
+	async assertJsonEventData<T>(expected: T, timeout = 5000): Promise<void> {
+		const event = await this.waitForEvent(timeout)
+		const parsed = JSON.parse(event.data) as unknown
+		expect(parsed).toEqual(expected)
+	}
+
+	/**
+	 * Access the raw Response
+	 */
+	get raw(): Response {
+		return this.response
+	}
+
+	private startReading(): void {
+		const body = this.response.body
+		if (!body) {
+			this.streamEnded = true
+			return
+		}
+
+		const reader = body.getReader() as ReadableStreamDefaultReader<Uint8Array>
+		const decoder = new TextDecoder()
+		let buffer = ''
+
+		const read = async (): Promise<void> => {
+			try {
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+				while (true) {
+					const { done, value } = await reader.read()
+
+					if (done) {
+						// Parse any remaining buffered data
+						if (buffer.trim()) {
+							const event = this.parseEvent(buffer)
+							if (event) this.dispatchEvent(event)
+						}
+						this.streamEnded = true
+						for (const waiter of this.endWaiters) {
+							waiter()
+						}
+						this.endWaiters = []
+						return
+					}
+
+					buffer += decoder.decode(value, { stream: true })
+
+					// Split on double newlines (SSE event boundary)
+					const parts = buffer.split('\n\n')
+					// Last part may be incomplete, keep it in the buffer
+					buffer = parts.pop()!
+
+					for (const part of parts) {
+						if (!part.trim()) continue
+						const event = this.parseEvent(part)
+						if (event) this.dispatchEvent(event)
+					}
+				}
+			} catch {
+				this.streamEnded = true
+				for (const waiter of this.endWaiters) {
+					waiter()
+				}
+				this.endWaiters = []
+			}
+		}
+
+		void read()
+	}
+
+	private parseEvent(raw: string): TestSseEvent | null {
+		const lines = raw.split('\n')
+		const dataLines: string[] = []
+		let event: string | undefined
+		let id: string | undefined
+		let retry: number | undefined
+
+		for (const line of lines) {
+			if (line.startsWith(':')) continue // comment line
+
+			const colonIndex = line.indexOf(':')
+			if (colonIndex === -1) continue
+
+			const field = line.slice(0, colonIndex)
+			// Strip optional leading space after colon
+			const value = line[colonIndex + 1] === ' ' ? line.slice(colonIndex + 2) : line.slice(colonIndex + 1)
+
+			switch (field) {
+				case 'data':
+					dataLines.push(value)
+					break
+				case 'event':
+					event = value
+					break
+				case 'id':
+					id = value
+					break
+				case 'retry': {
+					const parsed = parseInt(value, 10)
+					if (!isNaN(parsed)) retry = parsed
+					break
+				}
+			}
+		}
+
+		if (dataLines.length === 0) return null
+
+		const result: TestSseEvent = { data: dataLines.join('\n') }
+		if (event !== undefined) result.event = event
+		if (id !== undefined) result.id = id
+		if (retry !== undefined) result.retry = retry
+
+		return result
+	}
+
+	private dispatchEvent(event: TestSseEvent): void {
+		if (this.eventWaiters.length > 0) {
+			this.eventWaiters.shift()!(event)
+		} else {
+			this.eventQueue.push(event)
+		}
+	}
+}

--- a/packages/testing/src/core/sse/test-sse-request.ts
+++ b/packages/testing/src/core/sse/test-sse-request.ts
@@ -3,27 +3,26 @@ import { AUTH_SERVICE } from '@stratal/framework/auth'
 import { expect } from 'vitest'
 import { ActingAs } from '../../auth'
 import type { TestingModule } from '../testing-module'
-import { TestWsConnection } from './test-ws-connection'
+import { TestSseConnection } from './test-sse-connection'
 
 /**
- * TestWsRequest
+ * TestSseRequest
  *
- * Builder for WebSocket upgrade requests. Follows the TestHttpRequest pattern.
+ * Builder for SSE connection requests. Follows the TestWsRequest pattern.
  *
  * @example
  * ```typescript
- * const ws = await module.ws('/ws/chat').connect()
- * ws.send('hello')
- * await ws.assertMessage('echo:hello')
- * ws.close()
+ * const sse = await module.sse('/streaming/sse').connect()
+ * await sse.assertEvent({ event: 'message', data: 'hello' })
+ * await sse.waitForEnd()
  * ```
  *
- * @example Authenticated WebSocket
+ * @example Authenticated SSE
  * ```typescript
- * const ws = await module.ws('/ws/chat').actingAs({ id: user.id }).connect()
+ * const sse = await module.sse('/streaming/sse').actingAs({ id: user.id }).connect()
  * ```
  */
-export class TestWsRequest {
+export class TestSseRequest {
 	private requestHeaders: Headers = new Headers()
 	private actingAsUser: { id: string } | null = null
 
@@ -33,7 +32,7 @@ export class TestWsRequest {
 	) { }
 
 	/**
-	 * Add custom headers to the upgrade request
+	 * Add custom headers to the request
 	 */
 	withHeaders(headers: Record<string, string>): this {
 		for (const [key, value] of Object.entries(headers)) {
@@ -43,7 +42,7 @@ export class TestWsRequest {
 	}
 
 	/**
-	 * Authenticate the WebSocket connection as a specific user
+	 * Authenticate the SSE connection as a specific user
 	 */
 	actingAs(user: { id: string }): this {
 		this.actingAsUser = user
@@ -51,15 +50,12 @@ export class TestWsRequest {
 	}
 
 	/**
-	 * Send the upgrade request and return a live WebSocket connection
+	 * Send the request and return a live SSE connection
 	 */
-	async connect(): Promise<TestWsConnection> {
+	async connect(): Promise<TestSseConnection> {
 		await this.applyAuthentication()
 
-		this.requestHeaders.set('Upgrade', 'websocket')
-		this.requestHeaders.set('Connection', 'Upgrade')
-		this.requestHeaders.set('Sec-WebSocket-Key', 'dGhlIHNhbXBsZSBub25jZQ==')
-		this.requestHeaders.set('Sec-WebSocket-Version', '13')
+		this.requestHeaders.set('Accept', 'text/event-stream')
 
 		const url = new URL(this.path, 'http://localhost')
 		const request = new Request(url.toString(), {
@@ -70,17 +66,16 @@ export class TestWsRequest {
 
 		expect(
 			response.status,
-			`Expected status 101 (Switching Protocols), got ${response.status}`,
-		).toBe(101)
+			`Expected status 200, got ${response.status}`,
+		).toBe(200)
 
-		const ws = (response as Response & { webSocket: WebSocket | null }).webSocket
-		if (!ws) {
-			throw new Error('Response did not include a WebSocket connection')
-		}
+		const contentType = response.headers.get('content-type') ?? ''
+		expect(
+			contentType.includes('text/event-stream'),
+			`Expected content-type "text/event-stream", got "${contentType}"`,
+		).toBe(true)
 
-		ws.accept()
-
-		return new TestWsConnection(ws)
+		return new TestSseConnection(response)
 	}
 
 	private async applyAuthentication(): Promise<void> {

--- a/packages/testing/src/core/testing-module.ts
+++ b/packages/testing/src/core/testing-module.ts
@@ -4,9 +4,11 @@ import type { Application, StratalEnv } from 'stratal'
 import { DI_TOKENS, type Container } from 'stratal/di'
 import { type InjectionToken } from 'stratal/module'
 import { STORAGE_TOKENS } from 'stratal/storage'
+import { expect } from 'vitest'
 import type { FakeStorageService } from '../storage'
 import type { Seeder } from '../types'
 import { TestHttpClient } from './http/test-http-client'
+import { TestSseRequest } from './sse/test-sse-request'
 import { TestWsRequest } from './ws/test-ws-request'
 
 /**
@@ -78,6 +80,13 @@ export class TestingModule {
    */
   ws(path: string): TestWsRequest {
     return new TestWsRequest(path, this)
+  }
+
+  /**
+   * Create an SSE test request builder for the given path
+   */
+  sse(path: string): TestSseRequest {
+    return new TestSseRequest(path, this)
   }
 
   /**
@@ -162,7 +171,6 @@ export class TestingModule {
    * Assert that a record exists in the database
    */
   async assertDatabaseHas(table: string, data: Record<string, unknown>, name?: ConnectionName): Promise<void> {
-    const { expect } = await import('vitest')
     const db = this.getDb(name!)
     const model = (db as unknown as Record<string, unknown>)[table] as { findFirst: (opts: unknown) => Promise<unknown> }
     const result = await model.findFirst({ where: data })
@@ -173,7 +181,6 @@ export class TestingModule {
    * Assert that a record does not exist in the database
    */
   async assertDatabaseMissing(table: string, data: Record<string, unknown>, name?: ConnectionName): Promise<void> {
-    const { expect } = await import('vitest')
     const db = this.getDb(name!)
     const model = (db as unknown as Record<string, unknown>)[table] as { findFirst: (opts: unknown) => Promise<unknown> }
     const result = await model.findFirst({ where: data })
@@ -184,7 +191,6 @@ export class TestingModule {
    * Assert the number of records in a table
    */
   async assertDatabaseCount(table: string, expected: number, name?: ConnectionName): Promise<void> {
-    const { expect } = await import('vitest')
     const db = this.getDb(name!)
     const model = (db as unknown as Record<string, unknown>)[table] as { count: () => Promise<number> }
     const actual = await model.count()

--- a/packages/testing/src/core/testing-module.ts
+++ b/packages/testing/src/core/testing-module.ts
@@ -7,6 +7,7 @@ import { STORAGE_TOKENS } from 'stratal/storage'
 import type { FakeStorageService } from '../storage'
 import type { Seeder } from '../types'
 import { TestHttpClient } from './http/test-http-client'
+import { TestWsRequest } from './ws/test-ws-request'
 
 /**
  * TestingModule
@@ -70,6 +71,13 @@ export class TestingModule {
    */
   get storage(): FakeStorageService {
     return this.get<FakeStorageService>(STORAGE_TOKENS.StorageService)
+  }
+
+  /**
+   * Create a WebSocket test request builder for the given path
+   */
+  ws(path: string): TestWsRequest {
+    return new TestWsRequest(path, this)
   }
 
   /**

--- a/packages/testing/src/core/ws/index.ts
+++ b/packages/testing/src/core/ws/index.ts
@@ -1,0 +1,2 @@
+export { TestWsRequest } from './test-ws-request'
+export { TestWsConnection } from './test-ws-connection'

--- a/packages/testing/src/core/ws/test-ws-connection.ts
+++ b/packages/testing/src/core/ws/test-ws-connection.ts
@@ -62,16 +62,18 @@ export class TestWsConnection {
 		}
 
 		return new Promise<string | ArrayBuffer>((resolve, reject) => {
+			const waiter = (data: string | ArrayBuffer) => {
+				clearTimeout(timer)
+				resolve(data)
+			}
+
 			const timer = setTimeout(() => {
-				const index = this.messageWaiters.indexOf(resolve)
+				const index = this.messageWaiters.indexOf(waiter)
 				if (index !== -1) this.messageWaiters.splice(index, 1)
 				reject(new Error(`WebSocket: no message received within ${timeout}ms`))
 			}, timeout)
 
-			this.messageWaiters.push((data) => {
-				clearTimeout(timer)
-				resolve(data)
-			})
+			this.messageWaiters.push(waiter)
 		})
 	}
 
@@ -84,14 +86,18 @@ export class TestWsConnection {
 		}
 
 		return new Promise<{ code?: number; reason?: string }>((resolve, reject) => {
+			const waiter = (event: { code?: number; reason?: string }) => {
+				clearTimeout(timer)
+				resolve(event)
+			}
+
 			const timer = setTimeout(() => {
+				const index = this.closeWaiters.indexOf(waiter)
+				if (index !== -1) this.closeWaiters.splice(index, 1)
 				reject(new Error(`WebSocket: connection did not close within ${timeout}ms`))
 			}, timeout)
 
-			this.closeWaiters.push((event) => {
-				clearTimeout(timer)
-				resolve(event)
-			})
+			this.closeWaiters.push(waiter)
 		})
 	}
 

--- a/packages/testing/src/core/ws/test-ws-connection.ts
+++ b/packages/testing/src/core/ws/test-ws-connection.ts
@@ -1,0 +1,123 @@
+/**
+ * TestWsConnection
+ *
+ * Live WebSocket connection wrapper with assertion helpers for testing.
+ *
+ * @example
+ * ```typescript
+ * const ws = await module.ws('/ws/chat').connect()
+ * ws.send('hello')
+ * await ws.assertMessage('echo:hello')
+ * ws.close()
+ * await ws.waitForClose()
+ * ```
+ */
+export class TestWsConnection {
+	private readonly messageQueue: (string | ArrayBuffer)[] = []
+	private messageWaiters: ((data: string | ArrayBuffer) => void)[] = []
+	private closeEvent: { code?: number; reason?: string } | null = null
+	private closeWaiters: ((event: { code?: number; reason?: string }) => void)[] = []
+
+	constructor(private readonly ws: WebSocket) {
+		this.ws.addEventListener('message', (event: MessageEvent) => {
+			const data = event.data as string | ArrayBuffer
+			if (this.messageWaiters.length > 0) {
+				this.messageWaiters.shift()!(data)
+			} else {
+				this.messageQueue.push(data)
+			}
+		})
+
+		this.ws.addEventListener('close', (event: CloseEvent) => {
+			this.closeEvent = { code: event.code, reason: event.reason }
+			for (const waiter of this.closeWaiters) {
+				waiter(this.closeEvent)
+			}
+			this.closeWaiters = []
+		})
+	}
+
+	/**
+	 * Send a message through the WebSocket
+	 */
+	send(data: string | ArrayBuffer | Uint8Array): void {
+		this.ws.send(data)
+	}
+
+	/**
+	 * Close the WebSocket connection
+	 */
+	close(code?: number, reason?: string): void {
+		this.ws.close(code, reason)
+	}
+
+	/**
+	 * Wait for the next message, returning its data
+	 */
+	async waitForMessage(timeout = 5000): Promise<string | ArrayBuffer> {
+		if (this.messageQueue.length > 0) {
+			return this.messageQueue.shift()!
+		}
+
+		return new Promise<string | ArrayBuffer>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				const index = this.messageWaiters.indexOf(resolve)
+				if (index !== -1) this.messageWaiters.splice(index, 1)
+				reject(new Error(`WebSocket: no message received within ${timeout}ms`))
+			}, timeout)
+
+			this.messageWaiters.push((data) => {
+				clearTimeout(timer)
+				resolve(data)
+			})
+		})
+	}
+
+	/**
+	 * Wait for the connection to close
+	 */
+	async waitForClose(timeout = 5000): Promise<{ code?: number; reason?: string }> {
+		if (this.closeEvent) {
+			return this.closeEvent
+		}
+
+		return new Promise<{ code?: number; reason?: string }>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				reject(new Error(`WebSocket: connection did not close within ${timeout}ms`))
+			}, timeout)
+
+			this.closeWaiters.push((event) => {
+				clearTimeout(timer)
+				resolve(event)
+			})
+		})
+	}
+
+	/**
+	 * Assert that the next message equals the expected value
+	 */
+	async assertMessage(expected: string, timeout = 5000): Promise<void> {
+		const { expect } = await import('vitest')
+		const data = await this.waitForMessage(timeout)
+		const message = typeof data === 'string' ? data : '[ArrayBuffer]'
+		expect(message, `Expected WebSocket message "${expected}", got "${message}"`).toBe(expected)
+	}
+
+	/**
+	 * Assert that the connection closes, optionally with an expected code
+	 */
+	async assertClosed(expectedCode?: number, timeout = 5000): Promise<void> {
+		const { expect } = await import('vitest')
+		const event = await this.waitForClose(timeout)
+		if (expectedCode !== undefined) {
+			expect(event.code, `Expected close code ${expectedCode}, got ${event.code}`).toBe(expectedCode)
+		}
+	}
+
+	/**
+	 * Access the raw Cloudflare WebSocket
+	 */
+	get raw(): WebSocket {
+		return this.ws
+	}
+}

--- a/packages/testing/src/core/ws/test-ws-connection.ts
+++ b/packages/testing/src/core/ws/test-ws-connection.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 /**
  * TestWsConnection
  *
@@ -97,7 +99,6 @@ export class TestWsConnection {
 	 * Assert that the next message equals the expected value
 	 */
 	async assertMessage(expected: string, timeout = 5000): Promise<void> {
-		const { expect } = await import('vitest')
 		const data = await this.waitForMessage(timeout)
 		const message = typeof data === 'string' ? data : '[ArrayBuffer]'
 		expect(message, `Expected WebSocket message "${expected}", got "${message}"`).toBe(expected)
@@ -107,7 +108,6 @@ export class TestWsConnection {
 	 * Assert that the connection closes, optionally with an expected code
 	 */
 	async assertClosed(expectedCode?: number, timeout = 5000): Promise<void> {
-		const { expect } = await import('vitest')
 		const event = await this.waitForClose(timeout)
 		if (expectedCode !== undefined) {
 			expect(event.code, `Expected close code ${expectedCode}, got ${event.code}`).toBe(expectedCode)

--- a/packages/testing/src/core/ws/test-ws-request.ts
+++ b/packages/testing/src/core/ws/test-ws-request.ts
@@ -1,0 +1,99 @@
+import type { AuthService } from '@stratal/framework/auth'
+import { AUTH_SERVICE } from '@stratal/framework/auth'
+import { ActingAs } from '../../auth'
+import type { TestingModule } from '../testing-module'
+import { TestWsConnection } from './test-ws-connection'
+
+/**
+ * TestWsRequest
+ *
+ * Builder for WebSocket upgrade requests. Follows the TestHttpRequest pattern.
+ *
+ * @example
+ * ```typescript
+ * const ws = await module.ws('/ws/chat').connect()
+ * ws.send('hello')
+ * await ws.assertMessage('echo:hello')
+ * ws.close()
+ * ```
+ *
+ * @example Authenticated WebSocket
+ * ```typescript
+ * const ws = await module.ws('/ws/chat').actingAs({ id: user.id }).connect()
+ * ```
+ */
+export class TestWsRequest {
+	private requestHeaders: Headers = new Headers()
+	private actingAsUser: { id: string } | null = null
+
+	constructor(
+		private readonly path: string,
+		private readonly module: TestingModule,
+	) {}
+
+	/**
+	 * Add custom headers to the upgrade request
+	 */
+	withHeaders(headers: Record<string, string>): this {
+		for (const [key, value] of Object.entries(headers)) {
+			this.requestHeaders.set(key, value)
+		}
+		return this
+	}
+
+	/**
+	 * Authenticate the WebSocket connection as a specific user
+	 */
+	actingAs(user: { id: string }): this {
+		this.actingAsUser = user
+		return this
+	}
+
+	/**
+	 * Send the upgrade request and return a live WebSocket connection
+	 */
+	async connect(): Promise<TestWsConnection> {
+		await this.applyAuthentication()
+
+		this.requestHeaders.set('Upgrade', 'websocket')
+		this.requestHeaders.set('Connection', 'Upgrade')
+		this.requestHeaders.set('Sec-WebSocket-Key', 'dGhlIHNhbXBsZSBub25jZQ==')
+		this.requestHeaders.set('Sec-WebSocket-Version', '13')
+
+		const url = new URL(this.path, 'http://localhost')
+		const request = new Request(url.toString(), {
+			headers: this.requestHeaders,
+		})
+
+		const response = await this.module.fetch(request)
+
+		const { expect } = await import('vitest')
+		expect(
+			response.status,
+			`Expected status 101 (Switching Protocols), got ${response.status}`,
+		).toBe(101)
+
+		const ws = (response as Response & { webSocket: WebSocket | null }).webSocket
+		if (!ws) {
+			throw new Error('Response did not include a WebSocket connection')
+		}
+
+		ws.accept()
+
+		return new TestWsConnection(ws)
+	}
+
+	private async applyAuthentication(): Promise<void> {
+		if (!this.actingAsUser) return
+
+		await this.module.runInRequestScope(async () => {
+			const authService = this.module.get<AuthService>(AUTH_SERVICE)
+			const actingAs = new ActingAs(authService)
+			const authHeaders = this.actingAsUser ? await actingAs.createSessionForUser(this.actingAsUser) : new Headers()
+
+			for (const [key, value] of authHeaders.entries()) {
+				this.requestHeaders.set(key, value)
+			}
+		})
+	}
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -15,6 +15,11 @@ export { TestResponse } from './core/http/test-response'
 export { TestWsRequest } from './core/ws/test-ws-request'
 export { TestWsConnection } from './core/ws/test-ws-connection'
 
+// SSE Testing
+export { TestSseRequest } from './core/sse/test-sse-request'
+export { TestSseConnection } from './core/sse/test-sse-connection'
+export type { TestSseEvent } from './core/sse/test-sse-connection'
+
 // Re-export MSW utilities for convenience
 export { http, HttpResponse } from 'msw'
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -11,6 +11,10 @@ export { TestHttpClient } from './core/http/test-http-client'
 export { TestHttpRequest } from './core/http/test-http-request'
 export { TestResponse } from './core/http/test-response'
 
+// WebSocket Testing
+export { TestWsRequest } from './core/ws/test-ws-request'
+export { TestWsConnection } from './core/ws/test-ws-connection'
+
 // Re-export MSW utilities for convenience
 export { http, HttpResponse } from 'msw'
 


### PR DESCRIPTION
## Summary
Adds first-class WebSocket gateway support to the core framework via `@Gateway`, `@OnMessage`, `@OnClose`, and `@OnError` decorators, along with `GatewayContext` that extends `RouterContext` with WebSocket-specific methods. Adds testing utilities for both WebSocket (`TestWsRequest`/`TestWsConnection`) and SSE (`TestSseRequest`/`TestSseConnection`) to `@stratal/testing`.

## How to Test
- Run `yarn workspace stratal test src/websocket/__tests__/websocket.spec.ts` for decorator and context unit tests
- Run `yarn workspace stratal test test/integration/websocket.spec.ts` for integration tests
- Run `yarn workspace stratal test test/integration/streaming.spec.ts` for SSE streaming tests
- Verify `yarn workspace stratal typecheck` and `yarn workspace @stratal/testing typecheck` pass
- Confirm new `stratal/websocket` sub-path export resolves correctly

## Breaking Changes
- `ContextQueryResult` type is now exported and its definition changed — `R extends undefined` now returns `Record<string, unknown>` instead of `undefined`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket gateways with decorators and a Gateway context for real-time endpoints.
  * SSE and WebSocket testing utilities offering fluent builders, live-connection helpers, and assertion methods.
  * App/router configuration now awaits asynchronous setup to ensure configuration completes before startup steps.

* **Documentation**
  * Expanded docs and examples for WebSocket gateways, streaming/SSE APIs, and testing workflows.

* **Tests**
  * New and updated tests covering WebSocket gateways and SSE streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->