### PR TITLE
feat(inertia): stream server-side rendering with React 19

### DIFF
--- a/.agents/skills/stratal/references/inertia.md
+++ b/.agents/skills/stratal/references/inertia.md
@@ -25,7 +25,7 @@ import { InertiaModule, CookieFlashStore } from '@stratal/inertia'
       },
       i18n: { only: ['common', 'nav'] },         // Share translations with frontend
       ssr: {
-        bundle: () => import('./ssr-bundle'),     // SSR bundle (async import)
+        bundle: () => import('./inertia/ssr'),     // SSR bundle (async import)
         disabled: ['admin/*'],                    // Glob patterns to skip SSR
       },
     }),
@@ -41,7 +41,7 @@ InertiaModule.forRootAsync({
   inject: [CONFIG_TOKEN],
   useFactory: (config) => ({
     rootView: config.rootView,
-    ssr: { bundle: () => import('./ssr-bundle') },
+    ssr: { bundle: () => import('./inertia/ssr') },
   }),
 })
 ```
@@ -552,20 +552,50 @@ resolveUrl('users.show', { id }, routes, currentRoute, trailingSlash)
 
 ## SSR
 
+SSR is **streamed** (React 19 `renderToReadableStream`): the document shell (server
+SEO + Vite CSS) flushes immediately and the app body streams progressively, lowering
+TTFB. There is **no client-side fallback** — if the SSR bundle fails to load or render,
+the error surfaces (500) rather than silently degrading.
+
 ### Configuration
 
 ```typescript
 ssr: {
-  bundle: () => import('./ssr-bundle'),    // Dynamic import of SSR bundle
-  disabled: ['admin/*', 'settings/*'],     // Glob patterns to skip SSR
+  bundle: () => import('./inertia/ssr'),   // Dynamic import of the streaming SSR bundle
+  disabled: ['admin/*', 'settings/*'],     // Glob patterns to skip SSR (buffered client-only render)
 }
 ```
+
+### The SSR bundle (`src/inertia/ssr.tsx`)
+
+Use `createInertiaSsrApp` from `@stratal/inertia/ssr` — it wires Inertia's `App`,
+head collection, and `renderToReadableStream`, returning the `render(page)` the module
+expects. `quarry inertia:install` scaffolds this file.
+
+```tsx
+import { createInertiaSsrApp } from '@stratal/inertia/ssr'
+
+export const { render } = createInertiaSsrApp({
+  resolve: async (name) => {
+    const pages = import.meta.glob('./pages/**/*.tsx')
+    const page = await pages[`./pages/${name}.tsx`]?.()
+    if (!page) throw new Error(`Page not found: ${name}`)
+    return page
+  },
+  // Optional provider wrapper (theme, store, …):
+  // setup: ({ App, props }) => <ThemeProvider><App {...props} /></ThemeProvider>,
+})
+```
+
+> Inertia's `<Head>` tags are collected during the synchronous shell render. A `<Head>`
+> inside a *suspended* boundary won't reach `<head>` — use server-side `ctx.seo()` for
+> document metadata (the blessed path), which is resolved before render regardless.
 
 ### Per-Route SSR Opt-Out
 
 ```typescript
 async show(ctx: RouterContext): Promise<Response> {
-  ctx.withoutSsr()  // Skip SSR for this specific render
+  ctx.withoutSsr()  // Skip SSR for this render (buffered client-only response)
   return ctx.inertia('notes/Show', { note })
 }
 ```

--- a/.changeset/streaming-ssr-inertia.md
+++ b/.changeset/streaming-ssr-inertia.md
@@ -6,6 +6,10 @@ Stream server-side rendering with React 19 for faster TTFB and progressive Suspe
 
 The document shell (SEO + CSS) now flushes immediately while the app body streams, and `React.lazy`/`Suspense` boundaries stream in progressively instead of blocking the whole response. A new `createInertiaSsrApp` helper from `@stratal/inertia/ssr` wires this up for you. `quarry inertia:install` scaffolds an `src/inertia/ssr.tsx` using it.
 
+`createInertiaSsrApp` is generic over your page props — call `createInertiaSsrApp<MyProps>({ … })` to type the resolver, or omit the type argument to keep the `import.meta.glob` resolver opaque (the default). A downstream cancellation (client disconnect) now propagates to the React render, and an invalid resolver result throws instead of rendering nothing.
+
+Also fixes `ssr.disabled` glob matching, which previously compared against the full URL and so missed routes carrying a query string (e.g. `admin/*` vs `/admin/dashboard?tab=users`); it now matches the pathname only. Rerunning `quarry inertia:install` on an existing install now wires the SSR bundle into the current `InertiaModule.forRoot({ … })` instead of leaving SSR silently disabled.
+
 ### Breaking Changes
 
 - The SSR bundle now returns a stream, and there is no longer a silent client-side fallback — if SSR fails to load or render, the error surfaces (500) instead of degrading silently.

--- a/.changeset/streaming-ssr-inertia.md
+++ b/.changeset/streaming-ssr-inertia.md
@@ -1,0 +1,27 @@
+---
+"@stratal/inertia": patch
+---
+
+Stream server-side rendering with React 19 for faster TTFB and progressive Suspense rendering
+
+The document shell (SEO + CSS) now flushes immediately while the app body streams, and `React.lazy`/`Suspense` boundaries stream in progressively instead of blocking the whole response. A new `createInertiaSsrApp` helper from `@stratal/inertia/ssr` wires this up for you. `quarry inertia:install` scaffolds an `src/inertia/ssr.tsx` using it.
+
+### Breaking Changes
+
+- The SSR bundle now returns a stream, and there is no longer a silent client-side fallback — if SSR fails to load or render, the error surfaces (500) instead of degrading silently.
+- Migrate your `src/inertia/ssr.tsx` to use the new helper:
+
+  ```tsx
+  import { createInertiaSsrApp } from '@stratal/inertia/ssr'
+
+  export const { render } = createInertiaSsrApp({
+    resolve: async (name) => {
+      const pages = import.meta.glob('./pages/**/*.tsx')
+      const page = await pages[`./pages/${name}.tsx`]?.()
+      if (!page) throw new Error(`Page not found: ${name}`)
+      return page
+    },
+  })
+  ```
+
+  Replace the previous `createInertiaApp` + `renderToString` setup, which returned `{ head, body }`. App-level providers go in the optional `setup` callback. Document metadata should come from server-side `ctx.seo()` — a `<Head>` inside a suspended boundary is not captured during streaming.

--- a/packages/inertia-modal/src/services/modal.service.ts
+++ b/packages/inertia-modal/src/services/modal.service.ts
@@ -129,9 +129,9 @@ export class ModalService {
     // page.url = modalURL in both the server-rendered HTML and the client
     // hydration pass. The Modal component renders null during SSR (effects
     // don't run server-side), so there is no hydration mismatch.
-    const ssrResult = await this.ssr.render(combinedPage)
-    const html = this.template.render(combinedPage, ssrResult.head, ssrResult.body)
-    return new Response(html, {
+    const { head, stream } = await this.ssr.render(combinedPage)
+    const body = this.template.renderStream(combinedPage, head, stream)
+    return new Response(body, {
       status: 200,
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
     })

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -16,7 +16,7 @@ Inertia.js v3 server adapter for [Stratal](https://github.com/strataljs/stratal)
 ## Features
 
 - **InertiaModule** — Drop-in Stratal module with `forRoot()` / `forRootAsync()` configuration
-- **Server-Side Rendering** — SSR support with configurable per-route disabling
+- **Streaming SSR** — React 19 `renderToReadableStream` streaming via `createInertiaSsrApp`, with configurable per-route disabling
 - **Shared Data** — Global shared props with static values or request-scoped resolvers
 - **@InertiaRoute Decorator** — Convention-based Inertia page routes with auto-applied response schema
 - **Partial Reloads** — Optional, deferred, and merge props for efficient data loading
@@ -81,6 +81,38 @@ export class NotesController {
   }
 }
 ```
+
+### Streaming SSR
+
+Enable SSR by pointing the module at a bundle that exports a streaming `render`:
+
+```typescript
+InertiaModule.forRoot({
+  rootView: 'app',
+  ssr: { bundle: () => import('./inertia/ssr') },
+})
+```
+
+`src/inertia/ssr.tsx` (scaffolded by `quarry inertia:install`) uses
+`createInertiaSsrApp`, which wires Inertia's `App`, head collection, and React 19's
+`renderToReadableStream` — the shell flushes early and the body streams progressively:
+
+```tsx
+import { createInertiaSsrApp } from '@stratal/inertia/ssr'
+
+export const { render } = createInertiaSsrApp({
+  resolve: async (name) => {
+    const pages = import.meta.glob('./pages/**/*.tsx')
+    const page = await pages[`./pages/${name}.tsx`]?.()
+    if (!page) throw new Error(`Page not found: ${name}`)
+    return page
+  },
+})
+```
+
+There is no client-side fallback — an SSR failure surfaces as an error rather than
+silently degrading. Skip SSR per route with `ctx.withoutSsr()` or globally with
+`ssr.disabled: ['admin/*']`.
 
 ## Documentation
 

--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/seo-runtime.d.mts",
       "import": "./dist/seo-runtime.mjs"
     },
+    "./ssr": {
+      "types": "./dist/ssr.d.mts",
+      "import": "./dist/ssr.mjs"
+    },
     "./testing": {
       "types": "./dist/testing.d.mts",
       "import": "./dist/testing.mjs"

--- a/packages/inertia/src/__tests__/inertia-install.command.spec.ts
+++ b/packages/inertia/src/__tests__/inertia-install.command.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { Project, SyntaxKind } from 'ts-morph'
+import { InertiaInstallCommand } from '../commands/inertia-install.command'
+
+// `ensureSsrWiring` is a pure helper over a ts-morph SourceFile (it doesn't touch
+// instance state), so we can drive it via the prototype against an in-memory file.
+type EnsureSsrWiring = (sourceFile: unknown, syntaxKind: typeof SyntaxKind) => string
+const ensureSsrWiring = (InertiaInstallCommand.prototype as unknown as { ensureSsrWiring: EnsureSsrWiring })
+  .ensureSsrWiring
+
+function wire(source: string): { result: string; text: string } {
+  const project = new Project({ useInMemoryFileSystem: true })
+  const sourceFile = project.createSourceFile('app.module.ts', source)
+  const result = ensureSsrWiring(sourceFile, SyntaxKind)
+  return { result, text: sourceFile.getFullText() }
+}
+
+describe('InertiaInstallCommand.ensureSsrWiring', () => {
+  it('adds the ssr bundle option to an existing forRoot that lacks it', () => {
+    const { result, text } = wire(`
+@Module({
+  imports: [InertiaModule.forRoot({ rootView })],
+})
+export class AppModule {}
+`)
+
+    expect(result).toBe('ssr-added')
+    expect(text).toContain("ssr: { bundle: () => import('./inertia/ssr') }")
+  })
+
+  it('leaves an already-wired forRoot untouched', () => {
+    const source = `
+@Module({
+  imports: [InertiaModule.forRoot({ rootView, ssr: { bundle: () => import('./inertia/ssr') } })],
+})
+export class AppModule {}
+`
+    const { result, text } = wire(source)
+
+    expect(result).toBe('unchanged')
+    expect(text).toBe(source)
+  })
+
+  it('reports unwired when the config is not a plain forRoot object literal', () => {
+    const { result, text } = wire(`
+@Module({
+  imports: [InertiaModule.forRootAsync({ useFactory: () => ({ rootView }) })],
+})
+export class AppModule {}
+`)
+
+    expect(result).toBe('unwired')
+    expect(text).not.toContain('./inertia/ssr')
+  })
+})

--- a/packages/inertia/src/__tests__/inertia.service.spec.ts
+++ b/packages/inertia/src/__tests__/inertia.service.spec.ts
@@ -526,6 +526,25 @@ describe('InertiaService', () => {
 
       expect(mockSsr.render).toHaveBeenCalled()
     })
+
+    it('matches ssr.disabled against the pathname even with a query string', async () => {
+      const ssrOptions: InertiaModuleOptions = {
+        rootView: '<html>@inertia</html>',
+        version: '1.0',
+        ssr: {
+          bundle: vi.fn() as unknown as InertiaModuleOptions['ssr'] extends { bundle: infer B } ? B : never,
+          disabled: ['admin/*'],
+        },
+      }
+
+      const ssrService = new InertiaService(ssrOptions, mockTemplate, mockSsr, mockSeo)
+      const ctx = createMockContext({ url: 'http://localhost/admin/dashboard?tab=users' })
+
+      await ssrService.render(ctx, 'AdminDashboard', {})
+
+      expect(mockSsr.render).not.toHaveBeenCalled()
+      expect(mockTemplate.renderClientOnly).toHaveBeenCalled()
+    })
   })
 
   describe('seo injection', () => {

--- a/packages/inertia/src/__tests__/inertia.service.spec.ts
+++ b/packages/inertia/src/__tests__/inertia.service.spec.ts
@@ -96,15 +96,23 @@ describe('InertiaService', () => {
   const options: InertiaModuleOptions = {
     rootView: '<html>@inertia</html>',
     version: '1.0',
+    ssr: {
+      bundle: vi.fn() as unknown as NonNullable<InertiaModuleOptions['ssr']>['bundle'],
+    },
+  }
+
+  function emptyStream(): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({ start(controller) { controller.close() } })
   }
 
   beforeEach(() => {
     mockTemplate = {
-      render: vi.fn().mockReturnValue('<html><div id="app"></div></html>'),
+      renderStream: vi.fn().mockReturnValue(emptyStream()),
+      renderClientOnly: vi.fn().mockReturnValue('<html><div id="app"></div></html>'),
     } as unknown as TemplateService
 
     mockSsr = {
-      render: vi.fn().mockResolvedValue({ head: [], body: '' }),
+      render: vi.fn().mockResolvedValue({ head: [], stream: emptyStream() }),
     } as unknown as SsrRendererService
 
     mockSeo = {
@@ -140,7 +148,7 @@ describe('InertiaService', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8')
       expect(mockSsr.render).toHaveBeenCalled()
-      expect(mockTemplate.render).toHaveBeenCalled()
+      expect(mockTemplate.renderStream).toHaveBeenCalled()
     })
 
     it('should include render options in page object when true', async () => {
@@ -479,7 +487,7 @@ describe('InertiaService', () => {
       await service.render(ctx, 'Home', { message: 'Hello' })
 
       expect(mockSsr.render).not.toHaveBeenCalled()
-      expect(mockTemplate.render).toHaveBeenCalled()
+      expect(mockTemplate.renderClientOnly).toHaveBeenCalled()
     })
 
     it('should skip SSR when URL matches ssr.disabled pattern', async () => {
@@ -498,7 +506,7 @@ describe('InertiaService', () => {
       await ssrService.render(ctx, 'AdminDashboard', {})
 
       expect(mockSsr.render).not.toHaveBeenCalled()
-      expect(mockTemplate.render).toHaveBeenCalled()
+      expect(mockTemplate.renderClientOnly).toHaveBeenCalled()
     })
 
     it('should perform SSR for non-matching URL patterns', async () => {
@@ -524,13 +532,13 @@ describe('InertiaService', () => {
     it('shares the resolved seo prop and injects its tags into the head', async () => {
       ;(mockSeo.resolve as ReturnType<typeof vi.fn>).mockResolvedValue({ title: 'Dashboard' })
       ;(mockSeo.tagsFor as ReturnType<typeof vi.fn>).mockReturnValue(['<title data-seo>Dashboard</title>'])
-      ;(mockSsr.render as ReturnType<typeof vi.fn>).mockResolvedValue({ head: ['<meta charset="utf-8" />'], body: '' })
+      ;(mockSsr.render as ReturnType<typeof vi.fn>).mockResolvedValue({ head: ['<meta charset="utf-8" />'], stream: emptyStream() })
 
       const ctx = createMockContext()
       await service.render(ctx, 'Home', { message: 'Hello' })
 
       expect(mockSeo.resolve).toHaveBeenCalledWith(ctx)
-      const [page, headArg] = (mockTemplate.render as ReturnType<typeof vi.fn>).mock.calls[0]
+      const [page, headArg] = (mockTemplate.renderStream as ReturnType<typeof vi.fn>).mock.calls[0]
       expect((page as Page).props).toMatchObject({ seo: { title: 'Dashboard' }, message: 'Hello' })
       expect((page as Page).sharedProps).toContain('seo')
       // SEO tags (hreflang now among them) are appended after the SSR head.

--- a/packages/inertia/src/__tests__/manifest.service.spec.ts
+++ b/packages/inertia/src/__tests__/manifest.service.spec.ts
@@ -90,5 +90,19 @@ describe('ManifestService', () => {
     it('throws when no manifest is injected on globalThis', () => {
       expect(() => createService()).toThrow(/production build is missing the Vite client manifest/)
     })
+
+    it('memoizes the derived head/script tag strings', () => {
+      (globalThis as ManifestGlobal).__STRATAL_INERTIA_MANIFEST__ = {
+        'src/inertia/app.tsx': {
+          file: 'assets/app-abc123.js',
+          css: ['assets/app-abc123.css'],
+          isEntry: true,
+        },
+      }
+
+      const service = createService()
+      expect(service.getHeadTags()).toBe(service.getHeadTags())
+      expect(service.getScriptTags()).toBe(service.getScriptTags())
+    })
   })
 })

--- a/packages/inertia/src/__tests__/manifest.service.spec.ts
+++ b/packages/inertia/src/__tests__/manifest.service.spec.ts
@@ -91,7 +91,7 @@ describe('ManifestService', () => {
       expect(() => createService()).toThrow(/production build is missing the Vite client manifest/)
     })
 
-    it('memoizes the derived head/script tag strings', () => {
+    it('memoizes the derived head/script tag strings (builds each once)', () => {
       (globalThis as ManifestGlobal).__STRATAL_INERTIA_MANIFEST__ = {
         'src/inertia/app.tsx': {
           file: 'assets/app-abc123.js',
@@ -101,8 +101,15 @@ describe('ManifestService', () => {
       }
 
       const service = createService()
+      // Spy on the builders to prove the result is cached, not rebuilt — string
+      // value-equality alone can't tell a memoized result from a fresh identical one.
+      const buildHead = vi.spyOn(service as unknown as { buildHeadTags(): string }, 'buildHeadTags')
+      const buildScripts = vi.spyOn(service as unknown as { buildScriptTags(): string }, 'buildScriptTags')
+
       expect(service.getHeadTags()).toBe(service.getHeadTags())
       expect(service.getScriptTags()).toBe(service.getScriptTags())
+      expect(buildHead).toHaveBeenCalledTimes(1)
+      expect(buildScripts).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/inertia/src/__tests__/ssr-renderer.service.spec.ts
+++ b/packages/inertia/src/__tests__/ssr-renderer.service.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Page } from '@inertiajs/core'
+import type { InertiaModuleOptions } from '../inertia.options'
+import { SsrRendererService } from '../services/ssr-renderer.service'
+import type { InertiaSsrBundle, InertiaSsrResult } from '../types'
+
+function createPage(): Page {
+  return {
+    component: 'Home',
+    props: { errors: {} },
+    url: '/',
+    version: null,
+    flash: {},
+    rememberedState: {},
+    rescuedProps: [],
+  }
+}
+
+function emptyResult(): InertiaSsrResult {
+  return { head: [], stream: new ReadableStream<Uint8Array>({ start: (c) => c.close() }) }
+}
+
+function createService(ssr: InertiaModuleOptions['ssr']): SsrRendererService {
+  return new (SsrRendererService as any)({ rootView: '', ssr })
+}
+
+describe('SsrRendererService', () => {
+  it('loads the SSR bundle once across multiple renders', async () => {
+    const bundle: InertiaSsrBundle = { render: vi.fn().mockResolvedValue(emptyResult()) }
+    const factory = vi.fn().mockResolvedValue(bundle)
+    const service = createService({ bundle: factory })
+
+    await service.render(createPage())
+    await service.render(createPage())
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(bundle.render).toHaveBeenCalledTimes(2)
+  })
+
+  it('unwraps a default export', async () => {
+    const bundle: InertiaSsrBundle = { render: vi.fn().mockResolvedValue(emptyResult()) }
+    const service = createService({ bundle: vi.fn().mockResolvedValue({ default: bundle }) })
+
+    await service.render(createPage())
+
+    expect(bundle.render).toHaveBeenCalledOnce()
+  })
+
+  it('throws when SSR is not configured', async () => {
+    const service = createService(undefined)
+    await expect(service.render(createPage())).rejects.toThrow(/not configured/)
+  })
+
+  it('propagates a bundle-load failure (no silent fallback) and allows retry', async () => {
+    const factory = vi.fn()
+      .mockRejectedValueOnce(new Error('import failed'))
+      .mockResolvedValueOnce({ render: vi.fn().mockResolvedValue(emptyResult()) })
+    const service = createService({ bundle: factory })
+
+    await expect(service.render(createPage())).rejects.toThrow('import failed')
+    // A later request retries the import rather than reusing the rejected promise.
+    await expect(service.render(createPage())).resolves.toBeDefined()
+    expect(factory).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/inertia/src/__tests__/ssr.spec.ts
+++ b/packages/inertia/src/__tests__/ssr.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Page } from '@inertiajs/core'
+import { createElement } from 'react'
+import { createInertiaSsrApp } from '../ssr'
+
+function createPage(): Page {
+  return {
+    component: 'Home',
+    props: { message: 'Hello', errors: {} },
+    url: '/',
+    version: null,
+    flash: {},
+    rememberedState: {},
+    rescuedProps: [],
+  }
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  for (; ;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  return out + decoder.decode()
+}
+
+const Home = ({ message }: { message: string }) => createElement('h1', null, message)
+
+describe('createInertiaSsrApp', () => {
+  it('returns a render() that resolves the component and yields { head, stream }', async () => {
+    const resolve = vi.fn().mockResolvedValue({ default: Home })
+    const { render } = createInertiaSsrApp({ resolve })
+
+    const result = await render(createPage())
+
+    expect(resolve).toHaveBeenCalledWith('Home')
+    expect(Array.isArray(result.head)).toBe(true)
+    const html = await readAll(result.stream)
+    expect(html).toContain('Hello')
+  })
+
+  it('supports a setup wrapper for providers', async () => {
+    const setup = vi.fn(({ App, props }) => createElement(App, props))
+    const { render } = createInertiaSsrApp({ resolve: () => Home, setup })
+
+    const result = await render(createPage())
+    const html = await readAll(result.stream)
+
+    expect(setup).toHaveBeenCalledOnce()
+    expect(html).toContain('Hello')
+  })
+})

--- a/packages/inertia/src/__tests__/ssr.spec.ts
+++ b/packages/inertia/src/__tests__/ssr.spec.ts
@@ -66,4 +66,14 @@ describe('createInertiaSsrApp', () => {
 
     await expect(render(createPage())).rejects.toThrow(/did not return a React component/)
   })
+
+  it('accepts a props type argument to type the resolver', async () => {
+    // With a type argument the resolver is typed (no casts); the bare `Home`
+    // component satisfies `ComponentType<{ message: string }>`.
+    const { render } = createInertiaSsrApp<{ message: string }>({ resolve: () => Home })
+
+    const html = await readAll((await render(createPage())).stream)
+
+    expect(html).toContain('Hello')
+  })
 })

--- a/packages/inertia/src/__tests__/ssr.spec.ts
+++ b/packages/inertia/src/__tests__/ssr.spec.ts
@@ -52,4 +52,18 @@ describe('createInertiaSsrApp', () => {
     expect(setup).toHaveBeenCalledOnce()
     expect(html).toContain('Hello')
   })
+
+  it('renders a bare (non-default-exported) component', async () => {
+    const { render } = createInertiaSsrApp({ resolve: () => Home })
+
+    const html = await readAll((await render(createPage())).stream)
+
+    expect(html).toContain('Hello')
+  })
+
+  it('throws when the resolver yields no component instead of rendering nothing', async () => {
+    const { render } = createInertiaSsrApp({ resolve: () => ({ default: undefined }) })
+
+    await expect(render(createPage())).rejects.toThrow(/did not return a React component/)
+  })
 })

--- a/packages/inertia/src/__tests__/template.service.spec.ts
+++ b/packages/inertia/src/__tests__/template.service.spec.ts
@@ -170,6 +170,22 @@ describe('TemplateService', () => {
       })
       await expect(readAll(service.renderStream(page, [], failing))).rejects.toThrow('boom')
     })
+
+    it('cancels the upstream React stream when the consumer cancels', async () => {
+      const { service } = createService()
+      let cancelled: unknown
+      const reactStream = new ReadableStream<Uint8Array>({
+        start(controller) { controller.enqueue(new TextEncoder().encode('<main/>')) },
+        cancel(reason) { cancelled = reason },
+      })
+
+      const out = service.renderStream(page, [], reactStream)
+      const reader = out.getReader()
+      await reader.read() // pull the shell + first chunk, leaving the React stream open
+      await reader.cancel('client gone')
+
+      expect(cancelled).toBe('client gone')
+    })
   })
 
   describe('renderClientOnly', () => {
@@ -196,5 +212,20 @@ describe('TemplateService', () => {
     const html = await readAll(service.renderStream(page, [], streamOf('<main/>')))
     expect(html).toContain('<link rel="stylesheet" href="/assets/app-abc.css" />')
     expect(html).toContain('<script type="module" src="/assets/app-abc.js"></script>')
+  })
+
+  it('fills placeholders regardless of which side of @inertia they sit on', async () => {
+    // @viteScripts placed in the <head> (before @inertia) must still resolve.
+    const { service } = createService({
+      rootView: '<head>@viteHead @viteScripts @inertiaHead</head><body>@inertia</body>',
+    })
+    const html = await readAll(service.renderStream(page, ['<title>T</title>'], streamOf('<main/>')))
+
+    expect(html).not.toContain('@viteScripts')
+    expect(html).not.toContain('@viteHead')
+    expect(html).not.toContain('@inertiaHead')
+    expect(html).toContain('<title>T</title>')
+    // dev manifest tags emitted in both the head-located script slot and head slot
+    expect(html).toContain('/@vite/client')
   })
 })

--- a/packages/inertia/src/__tests__/template.service.spec.ts
+++ b/packages/inertia/src/__tests__/template.service.spec.ts
@@ -13,6 +13,29 @@ function createManifest(options: Partial<InertiaModuleOptions> = {}): ManifestSe
   return new (ManifestService as any)({ rootView: '', ...options })
 }
 
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  for (; ;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
 beforeEach(() => {
   vi.stubEnv('DEV', true)
 })
@@ -48,56 +71,119 @@ describe('TemplateService', () => {
 
   const page = createPage()
 
-  it('should output script tag with page JSON and empty #app div without SSR', () => {
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-    const html = service.render(page, [], '')
-    expect(html).toContain('<script data-page="app" type="application/json">')
-    expect(html).toContain('<div id="app"></div>')
+  function createService(opts: InertiaModuleOptions = options): { service: any; manifest: ManifestService } {
+    const manifest = createManifest({ rootView: opts.rootView })
+    return { service: new (TemplateService as any)(opts, manifest), manifest }
+  }
+
+  it('throws when rootView is missing the @inertia placeholder', () => {
+    expect(() => createService({ rootView: '<html></html>' })).toThrow(/@inertia placeholder/)
   })
 
-  it('should use SSR body directly as the app container', () => {
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-    const ssrBody = '<script data-page="app" type="application/json">{}</script><div id="app" data-server-rendered="true"><h1>Hello</h1></div>'
-    const html = service.render(page, [], ssrBody)
-    expect(html).toContain(ssrBody)
-    // Should NOT double-wrap in another #app div
-    expect(html).not.toMatch(/<div id="app"[^>]*>.*<div id="app"/s)
-  })
+  describe('renderStream', () => {
+    it('wraps the React stream in a single server-rendered #app container', async () => {
+      const { service } = createService()
+      const html = await readAll(service.renderStream(page, [], streamOf('<h1>Hello</h1>')))
 
-  it('should replace @inertiaHead with SSR head tags', () => {
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-    const html = service.render(page, ['<title>Test</title>', '<meta name="desc" />'], '')
-    expect(html).toContain('<title>Test</title>')
-    expect(html).toContain('<meta name="desc" />')
-  })
-
-  it('should escape forward slashes in page JSON', () => {
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-    const xssPage = createPage({
-      props: { html: '</script><script>alert("xss")', errors: {} },
+      expect(html).toContain('<script data-page="app" type="application/json">')
+      expect(html).toContain('<div data-server-rendered="true" id="app">')
+      expect(html).toContain('<h1>Hello</h1>')
+      expect((html.match(/<div data-server-rendered="true" id="app">/g) ?? []).length).toBe(1)
+      expect(html.indexOf('<h1>Hello</h1>')).toBeGreaterThan(html.indexOf('<div data-server-rendered="true" id="app">'))
     })
-    const html = service.render(xssPage, [], '')
-    expect(html).not.toContain('</script><script>alert')
-    expect(html).toContain('<\\/script>')
+
+    it('flushes the head (vite + inertia head) before the streamed body', async () => {
+      const { service } = createService()
+      const html = await readAll(service.renderStream(page, ['<title>Test</title>', '<meta name="desc" />'], streamOf('<main/>')))
+
+      expect(html).toContain('<title>Test</title>')
+      expect(html).toContain('<meta name="desc" />')
+      expect(html.indexOf('<title>Test</title>')).toBeLessThan(html.indexOf('<main/>'))
+    })
+
+    it('escapes forward slashes in the page JSON to prevent script-tag breakout', async () => {
+      const { service } = createService()
+      const xssPage = createPage({ props: { html: '</script><script>alert("xss")', errors: {} } })
+      const html = await readAll(service.renderStream(xssPage, [], streamOf('<main/>')))
+
+      expect(html).not.toContain('</script><script>alert')
+      expect(html).toContain('<\\/script>')
+    })
+
+    it('preserves $-sequences in head content verbatim', async () => {
+      const { service } = createService()
+      const title = '<title>Buy now: $$$ &amp; save $&amp; — `$`` deals</title>'
+      const html = await readAll(service.renderStream(page, [title], streamOf('<main/>')))
+
+      expect(html).toContain(title)
+      expect(html).not.toContain('@inertiaHead')
+    })
+
+    it('streams progressively — flushes the shell and early chunks before later React chunks are produced', async () => {
+      const { service } = createService()
+      const encoder = new TextEncoder()
+
+      // A React stream that emits chunk A, then parks until the test releases it,
+      // then emits chunk B. Mirrors a Suspense boundary resolving after the shell.
+      let releaseB!: () => void
+      const bGate = new Promise<void>((resolve) => { releaseB = resolve })
+      const reactStream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(encoder.encode('<div>A</div>'))
+          await bGate
+          controller.enqueue(encoder.encode('<div>B</div>'))
+          controller.close()
+        },
+      })
+
+      const reader = service.renderStream(page, [], reactStream).getReader()
+      const decoder = new TextDecoder()
+      let out = ''
+
+      // Drain until chunk A is visible — all while B is still gated. If renderStream
+      // buffered the whole React stream (e.g. awaited allReady), this would hang/never
+      // see A without B, so we assert A arrived and B has NOT.
+      while (!out.includes('<div>A</div>')) {
+        const { done, value } = await reader.read()
+        if (done) break
+        out += decoder.decode(value, { stream: true })
+      }
+      expect(out).toContain('<div data-server-rendered="true" id="app">')
+      expect(out).toContain('<div>A</div>')
+      expect(out).not.toContain('<div>B</div>')
+
+      // Release B; it (and the closing markup) must arrive after A, in order.
+      releaseB()
+      for (; ;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        out += decoder.decode(value, { stream: true })
+      }
+      expect(out).toContain('<div>B</div>')
+      expect(out.indexOf('<div>A</div>')).toBeLessThan(out.indexOf('<div>B</div>'))
+    })
+
+    it('propagates errors from the React stream', async () => {
+      const { service } = createService()
+      const failing = new ReadableStream<Uint8Array>({
+        start(controller) { controller.error(new Error('boom')) },
+      })
+      await expect(readAll(service.renderStream(page, [], failing))).rejects.toThrow('boom')
+    })
   })
 
-  it('should preserve $-sequences in head/body content verbatim', () => {
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-    // A string replacement would interpret `$$`, `$&`, `$\`` and `$'` — corrupting
-    // SEO/page content that legitimately contains `$` and even splicing the
-    // placeholder token back in.
-    const title = '<title>Buy now: $$$ &amp; save $&amp; — `$`` deals</title>'
-    const html = service.render(page, [title], '')
-    expect(html).toContain(title)
-    expect(html).not.toContain('@inertiaHead')
+  describe('renderClientOnly', () => {
+    it('emits an empty #app div with the page JSON', () => {
+      const { service } = createService()
+      const html = service.renderClientOnly(page, [])
+      expect(html).toContain('<script data-page="app" type="application/json">')
+      expect(html).toContain('<div id="app"></div>')
+      expect(html).not.toContain('data-server-rendered')
+      expect(html).not.toContain('@inertia')
+    })
   })
 
-  it('should replace @viteHead and @viteScripts with manifest tags', () => {
+  it('resolves @viteHead and @viteScripts from the manifest in production', async () => {
     vi.stubEnv('DEV', false)
     ;(globalThis as ManifestGlobal).__STRATAL_INERTIA_MANIFEST__ = {
       'src/inertia/app.tsx': {
@@ -106,10 +192,8 @@ describe('TemplateService', () => {
         isEntry: true,
       },
     }
-    const manifest = createManifest()
-    const service = new (TemplateService as any)(options, manifest)
-
-    const html = service.render(page, [], '')
+    const { service } = createService()
+    const html = await readAll(service.renderStream(page, [], streamOf('<main/>')))
     expect(html).toContain('<link rel="stylesheet" href="/assets/app-abc.css" />')
     expect(html).toContain('<script type="module" src="/assets/app-abc.js"></script>')
   })

--- a/packages/inertia/src/commands/inertia-install.command.ts
+++ b/packages/inertia/src/commands/inertia-install.command.ts
@@ -1,7 +1,20 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
 import { Command } from 'stratal/quarry'
+import type { SourceFile, SyntaxKind } from 'ts-morph'
 import { runTypeGeneration } from '../generator/type-generator'
+
+/** Outcome of reconciling `src/app.module.ts` with the SSR-enabled InertiaModule. */
+type AppModuleUpdate = 'created' | 'ssr-added' | 'unchanged' | 'unwired'
+/**
+ * The subset of ts-morph's runtime `SyntaxKind` enum that `ensureSsrWiring` reads.
+ * Declared structurally (via the enum-member literal types) so ts-morph stays a
+ * type-only import here and is loaded lazily where it's actually used.
+ */
+interface SyntaxKinds {
+  CallExpression: SyntaxKind.CallExpression
+  ObjectLiteralExpression: SyntaxKind.ObjectLiteralExpression
+}
 
 const ROOT_HTML = `<!DOCTYPE html>
 <html lang="en">
@@ -92,11 +105,16 @@ export class InertiaInstallCommand extends Command {
     if (existsSync(appModulePath)) {
       this.info('Updating src/app.module.ts...')
       try {
-        const updated = await this.updateAppModule(appModulePath)
-        if (updated) {
+        const result = await this.updateAppModule(appModulePath)
+        if (result === 'created') {
           this.success('Updated src/app.module.ts with InertiaModule')
+        } else if (result === 'ssr-added') {
+          this.success('Enabled streaming SSR in src/app.module.ts')
+        } else if (result === 'unchanged') {
+          this.info('InertiaModule (with SSR) already configured in app.module.ts')
         } else {
-          this.info('InertiaModule already configured in app.module.ts')
+          this.warn('InertiaModule is configured but SSR could not be auto-wired.')
+          this.info("Add `ssr: { bundle: () => import('./inertia/ssr') }` to your InertiaModule options")
         }
       } catch (err) {
         this.warn(`Could not auto-update app.module.ts: ${(err as Error).message}`)
@@ -129,27 +147,29 @@ export class InertiaInstallCommand extends Command {
     return 0
   }
 
-  private async updateAppModule(modulePath: string): Promise<boolean> {
+  private async updateAppModule(modulePath: string): Promise<AppModuleUpdate> {
     const { Project, SyntaxKind } = await import('ts-morph')
 
     const project = new Project({ useInMemoryFileSystem: false })
     const sourceFile = project.addSourceFileAtPath(modulePath)
 
-    // Check if InertiaModule is already imported
+    // Already importing the package — an older install that predates streaming
+    // SSR. Wire the existing InertiaModule config to the SSR bundle rather than
+    // bailing (which would leave SSR silently disabled).
     const existingImport = sourceFile.getImportDeclaration((decl) =>
       decl.getModuleSpecifierValue() === '@stratal/inertia',
     )
     if (existingImport) {
-      return false
+      const result = this.ensureSsrWiring(sourceFile, SyntaxKind)
+      if (result === 'ssr-added') await sourceFile.save()
+      return result
     }
 
-    // Add rootView import
+    // Fresh install: add the imports and an InertiaModule.forRoot wired for SSR.
     sourceFile.addImportDeclaration({
       defaultImport: 'rootView',
       moduleSpecifier: './inertia/root.html?raw',
     })
-
-    // Add InertiaModule import
     sourceFile.addImportDeclaration({
       namedImports: ['InertiaModule'],
       moduleSpecifier: '@stratal/inertia',
@@ -187,6 +207,32 @@ export class InertiaInstallCommand extends Command {
     }
 
     await sourceFile.save()
-    return true
+    return 'created'
+  }
+
+  /**
+   * Ensure an existing `InertiaModule.forRoot({...})` call opts into the streaming
+   * SSR bundle. Returns `ssr-added` when the option is inserted, `unchanged` when
+   * one is already present, or `unwired` when no plain `forRoot({...})` object
+   * literal is found (e.g. `forRootAsync`, or a config passed by reference) — in
+   * which case the caller surfaces a manual instruction.
+   */
+  private ensureSsrWiring(sourceFile: SourceFile, syntaxKind: SyntaxKinds): AppModuleUpdate {
+    const calls = sourceFile.getDescendantsOfKind(syntaxKind.CallExpression)
+    for (const call of calls) {
+      if (call.getExpression().getText() !== 'InertiaModule.forRoot') continue
+
+      const objLiteral = call.getArguments()[0]?.asKind(syntaxKind.ObjectLiteralExpression)
+      if (!objLiteral) continue
+
+      if (objLiteral.getProperty('ssr')) return 'unchanged'
+
+      objLiteral.addPropertyAssignment({
+        name: 'ssr',
+        initializer: `{ bundle: () => import('./inertia/ssr') }`,
+      })
+      return 'ssr-added'
+    }
+    return 'unwired'
   }
 }

--- a/packages/inertia/src/commands/inertia-install.command.ts
+++ b/packages/inertia/src/commands/inertia-install.command.ts
@@ -28,6 +28,17 @@ createInertiaApp({
   },
 })`
 
+const SSR_TSX = `import { createInertiaSsrApp } from '@stratal/inertia/ssr'
+
+export const { render } = createInertiaSsrApp({
+  resolve: async (name) => {
+    const pages = import.meta.glob('./pages/**/*.tsx')
+    const page = await pages[\`./pages/\${name}.tsx\`]?.()
+    if (!page) throw new Error(\`Page not found: \${name}\`)
+    return page
+  },
+})`
+
 const HOME_TSX = `export default function Home({ message }: { message: string }) {
   return (
     <div>
@@ -63,6 +74,7 @@ export class InertiaInstallCommand extends Command {
     const files = [
       { path: join(inertiaDir, 'root.html'), content: ROOT_HTML, name: 'root.html' },
       { path: join(inertiaDir, 'app.tsx'), content: APP_TSX, name: 'app.tsx' },
+      { path: join(inertiaDir, 'ssr.tsx'), content: SSR_TSX, name: 'ssr.tsx' },
       { path: join(pagesDir, 'Home.tsx'), content: HOME_TSX, name: 'pages/Home.tsx' },
     ]
 
@@ -161,13 +173,13 @@ export class InertiaInstallCommand extends Command {
         const initializer = importsProp.asKind(SyntaxKind.PropertyAssignment)?.getInitializer()
         const arrayLiteral = initializer?.asKind(SyntaxKind.ArrayLiteralExpression)
         if (arrayLiteral) {
-          arrayLiteral.addElement(`InertiaModule.forRoot({\n    rootView,\n  })`)
+          arrayLiteral.addElement(`InertiaModule.forRoot({\n    rootView,\n    ssr: { bundle: () => import('./inertia/ssr') },\n  })`)
         }
       } else {
         // Add imports property
         objLiteral.addPropertyAssignment({
           name: 'imports',
-          initializer: `[\n    InertiaModule.forRoot({\n      rootView,\n    }),\n  ]`,
+          initializer: `[\n    InertiaModule.forRoot({\n      rootView,\n      ssr: { bundle: () => import('./inertia/ssr') },\n    }),\n  ]`,
         })
       }
 

--- a/packages/inertia/src/inertia.options.ts
+++ b/packages/inertia/src/inertia.options.ts
@@ -1,15 +1,11 @@
-import type { InertiaAppSSRResponse, Page } from '@inertiajs/core'
 import type { MessageKeyPrefix } from 'stratal/i18n'
 import type { RouterContext } from 'stratal/router'
 import type { FlashStore } from './flash/flash-store'
 import type { SeoData } from './seo/types'
-
-interface SsrBundleModule {
-  render(page: Page): Promise<InertiaAppSSRResponse>
-}
+import type { InertiaSsrBundle } from './types'
 
 export interface InertiaSsrOptions {
-  bundle: () => Promise<SsrBundleModule | { default: SsrBundleModule }>
+  bundle: () => Promise<InertiaSsrBundle | { default: InertiaSsrBundle }>
   /**
    * Route patterns where SSR is disabled (e.g., `"admin/*"`).
    * Uses simple glob matching against the request pathname.

--- a/packages/inertia/src/services/inertia.service.ts
+++ b/packages/inertia/src/services/inertia.service.ts
@@ -91,6 +91,8 @@ export class InertiaService {
   ): Promise<Response> {
     const reqUrl = new URL(ctx.c.req.url)
     const url = reqUrl.search ? `${reqUrl.pathname}${reqUrl.search}` : reqUrl.pathname
+    // `ssr.disabled` globs match the path only — keep the query string out of it.
+    const pathname = reqUrl.pathname
     const isInertia = ctx.c.get('inertia')
 
     // Resolve shared data from module options
@@ -156,7 +158,7 @@ export class InertiaService {
 
     // Full page render — skip SSR if disabled for this route or not configured
     const seoTags = this.seoService.tagsFor(resolvedSeo)
-    const ssrDisabled = ctx.c.get('withoutSsr') || this.isSsrDisabled(url) || !this.options.ssr
+    const ssrDisabled = ctx.c.get('withoutSsr') || this.isSsrDisabled(pathname) || !this.options.ssr
 
     if (ssrDisabled) {
       const html = this.template.renderClientOnly(page, seoTags)

--- a/packages/inertia/src/services/inertia.service.ts
+++ b/packages/inertia/src/services/inertia.service.ts
@@ -154,19 +154,26 @@ export class InertiaService {
       })
     }
 
-    // Full page render — skip SSR if disabled for this route
-    const ssrDisabled = ctx.c.get('withoutSsr') || this.isSsrDisabled(url)
-    const ssrResult = ssrDisabled
-      ? { head: [] as string[], body: '' }
-      : await this.ssr.render(page)
+    // Full page render — skip SSR if disabled for this route or not configured
     const seoTags = this.seoService.tagsFor(resolvedSeo)
-    const html = this.template.render(page, [...ssrResult.head, ...seoTags], ssrResult.body)
+    const ssrDisabled = ctx.c.get('withoutSsr') || this.isSsrDisabled(url) || !this.options.ssr
 
-    return new Response(html, {
+    if (ssrDisabled) {
+      const html = this.template.renderClientOnly(page, seoTags)
+      return new Response(html, {
+        status,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      })
+    }
+
+    // Streaming SSR: awaiting render resolves once the shell is ready (so the
+    // Inertia `<Head>` tags are known); the body then streams progressively.
+    const { head, stream } = await this.ssr.render(page)
+    const body = this.template.renderStream(page, [...head, ...seoTags], stream)
+
+    return new Response(body, {
       status,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-      },
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
     })
   }
 

--- a/packages/inertia/src/services/manifest.service.ts
+++ b/packages/inertia/src/services/manifest.service.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { Transient, inject } from 'stratal/di'
+import { Singleton, inject } from 'stratal/di'
 import type { InertiaModuleOptions } from '../inertia.options'
 import { INERTIA_TOKENS } from '../inertia.tokens'
 import type { ViteManifest } from '../types'
@@ -11,11 +11,15 @@ interface ManifestGlobal {
   __STRATAL_INERTIA_MANIFEST__?: ViteManifest
 }
 
-@Transient()
+@Singleton()
 export class ManifestService {
   private readonly manifest: ViteManifest | null
   private readonly entryClientPath: string
   private readonly isDev: boolean = Boolean(import.meta.env.DEV)
+  // The manifest is static for the lifetime of the worker, so the derived
+  // head/script tag strings are computed once and cached.
+  private headTags: string | null = null
+  private scriptTags: string | null = null
 
   constructor(
     @inject(INERTIA_TOKENS.Options) options: InertiaModuleOptions,
@@ -33,6 +37,14 @@ export class ManifestService {
   }
 
   getHeadTags(): string {
+    return this.headTags ??= this.buildHeadTags()
+  }
+
+  getScriptTags(): string {
+    return this.scriptTags ??= this.buildScriptTags()
+  }
+
+  private buildHeadTags(): string {
     if (this.isDev) {
       return '<link rel="stylesheet" href="/__inertia/ssr-css" data-ssr-css />'
     }
@@ -52,7 +64,7 @@ export class ManifestService {
     return tags.join('\n')
   }
 
-  getScriptTags(): string {
+  private buildScriptTags(): string {
     if (this.isDev) {
       return [
         '<script type="module" src="/@vite/client"></script>',

--- a/packages/inertia/src/services/ssr-renderer.service.ts
+++ b/packages/inertia/src/services/ssr-renderer.service.ts
@@ -1,9 +1,9 @@
-import type { Page } from '@inertiajs/core';
-import { Singleton, inject } from 'stratal/di';
-import { ApplicationError } from 'stratal/errors';
-import type { InertiaModuleOptions } from '../inertia.options';
-import { INERTIA_TOKENS } from '../inertia.tokens';
-import type { InertiaSsrBundle, InertiaSsrResult } from '../types';
+import type { Page } from '@inertiajs/core'
+import { Singleton, inject } from 'stratal/di'
+import { ApplicationError } from 'stratal/errors'
+import type { InertiaModuleOptions } from '../inertia.options'
+import { INERTIA_TOKENS } from '../inertia.tokens'
+import type { InertiaSsrBundle, InertiaSsrResult } from '../types'
 
 @Singleton()
 export class SsrRendererService {

--- a/packages/inertia/src/services/ssr-renderer.service.ts
+++ b/packages/inertia/src/services/ssr-renderer.service.ts
@@ -1,59 +1,50 @@
-import type { InertiaAppSSRResponse, Page } from '@inertiajs/core'
-import { Singleton, inject } from 'stratal/di'
-import { LOGGER_TOKENS, type LoggerService } from 'stratal/logger'
-import type { InertiaModuleOptions } from '../inertia.options'
-import { INERTIA_TOKENS } from '../inertia.tokens'
-
-interface LoadedSsrBundle {
-  render(page: Page): Promise<InertiaAppSSRResponse>
-}
+import type { Page } from '@inertiajs/core';
+import { Singleton, inject } from 'stratal/di';
+import { ApplicationError } from 'stratal/errors';
+import type { InertiaModuleOptions } from '../inertia.options';
+import { INERTIA_TOKENS } from '../inertia.tokens';
+import type { InertiaSsrBundle, InertiaSsrResult } from '../types';
 
 @Singleton()
 export class SsrRendererService {
-  private bundle: LoadedSsrBundle | null = null
+  private bundle: InertiaSsrBundle | null = null
   private loadPromise: Promise<void> | null = null
 
   constructor(
     @inject(INERTIA_TOKENS.Options) private readonly options: InertiaModuleOptions,
-    @inject(LOGGER_TOKENS.LoggerService) private readonly logger: LoggerService
   ) { }
 
-  async render(page: Page): Promise<InertiaAppSSRResponse> {
+  /**
+   * Render a page to a streaming SSR result.
+   *
+   * The SSR bundle is imported once per worker (memoized). Bundle-load and render
+   * errors propagate — there is no silent client-side fallback. Callers must only
+   * invoke this when `options.ssr` is configured.
+   */
+  async render(page: Page): Promise<InertiaSsrResult> {
     if (!this.options.ssr) {
-      return { head: [], body: '' }
+      throw new ApplicationError('[stratal:inertia] SSR bundle is not configured.')
     }
 
     await this.ensureBundle()
-
-    if (!this.bundle) {
-      return { head: [], body: '' }
-    }
-
-    return this.bundle.render(page)
+    return this.bundle!.render(page)
   }
 
   private async ensureBundle(): Promise<void> {
     if (this.bundle) return
-
     this.loadPromise ??= this.loadBundle()
-
     try {
       await this.loadPromise
-    } catch {
-      // loadBundle already clears loadPromise on failure
+    } catch (error) {
+      // Allow a later request to retry a transient import failure, but still
+      // surface the error to this request (no silent client-side fallback).
+      this.loadPromise = null
+      throw error
     }
   }
 
   private async loadBundle(): Promise<void> {
-    if (!this.options.ssr) return
-
-    try {
-      const mod = await this.options.ssr.bundle()
-      const resolved = ('default' in mod ? mod.default : mod) as LoadedSsrBundle
-      this.bundle = resolved
-    } catch (error: unknown) {
-      this.logger.warn('[stratal:inertia] Failed to load SSR bundle. Falling back to client-side rendering.', { error })
-      this.loadPromise = null
-    }
+    const mod = await this.options.ssr!.bundle()
+    this.bundle = ('default' in mod ? mod.default : mod)
   }
 }

--- a/packages/inertia/src/services/template.service.ts
+++ b/packages/inertia/src/services/template.service.ts
@@ -1,40 +1,95 @@
 import type { Page } from '@inertiajs/core'
-import { Transient, inject } from 'stratal/di'
+import { Singleton, inject } from 'stratal/di'
+import { ApplicationError } from 'stratal/errors'
 import type { InertiaModuleOptions } from '../inertia.options'
 import { INERTIA_TOKENS } from '../inertia.tokens'
 import type { ManifestService } from './manifest.service'
 
-@Transient()
+const APP_ID = 'app'
+
+@Singleton()
 export class TemplateService {
+  // The root template is split once around the @inertia placeholder so the
+  // document shell can be flushed before the React stream and closed after it.
+  private readonly pre: string
+  private readonly post: string
+
   constructor(
-    @inject(INERTIA_TOKENS.Options) private readonly options: InertiaModuleOptions,
+    @inject(INERTIA_TOKENS.Options) options: InertiaModuleOptions,
     @inject(INERTIA_TOKENS.ManifestService) private readonly manifest: ManifestService,
-  ) { }
-
-  render(page: Page, ssrHead: string[], ssrBody: string): string {
-    // When SSR body is present, Inertia's buildSSRBody already returns the
-    // <script data-page="app"> tag + <div id="app" data-server-rendered="true">.
-    // Without SSR, we generate both elements ourselves for client-side hydration.
-    const appHtml = ssrBody || this.buildClientOnlyBody(page)
-
-    const headTags = ssrHead.length > 0 ? ssrHead.join('\n') : ''
-    const viteHead = this.manifest.getHeadTags()
-    const viteScripts = this.manifest.getScriptTags()
-
-    // Use function replacements: a string replacement interprets `$$`, `$&`,
-    // `` $` `` and `$'` patterns, which would corrupt SEO/page content that
-    // legitimately contains a `$` (and could splice a placeholder token back in).
-    let html = this.options.rootView
-    html = html.replace('@inertiaHead', () => headTags)
-    html = html.replace('@inertia', () => appHtml)
-    html = html.replace('@viteHead', () => viteHead)
-    html = html.replace('@viteScripts', () => viteScripts)
-
-    return html
+  ) {
+    // Match the standalone @inertia token, not the @inertiaHead placeholder it
+    // is a prefix of (the word boundary fails between `a` and `H`).
+    const match = /@inertia\b/.exec(options.rootView)
+    if (!match) {
+      throw new ApplicationError('[stratal:inertia] rootView template is missing the @inertia placeholder.')
+    }
+    this.pre = options.rootView.slice(0, match.index)
+    this.post = options.rootView.slice(match.index + '@inertia'.length)
   }
 
-  private buildClientOnlyBody(page: Page): string {
-    const json = JSON.stringify(page).replace(/\//g, '\\/')
-    return `<script data-page="app" type="application/json">${json}</script><div id="app"></div>`
+  /**
+   * Compose the streamed HTML response: the document shell (head + opening
+   * `#app` wrapper) is flushed first, the React stream is piped verbatim, then
+   * the wrapper is closed and the trailing scripts are appended.
+   *
+   * Reproduces Inertia's `buildSSRBody` markup: a `<script data-page>` JSON tag
+   * (parsed before hydration) followed by `<div data-server-rendered id="app">`.
+   */
+  renderStream(page: Page, head: string[], reactStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    const shellPre = this.buildShell(head)
+      + `<script data-page="${APP_ID}" type="application/json">${this.serialize(page)}</script>`
+      + `<div data-server-rendered="true" id="${APP_ID}">`
+    const shellPost = `</div>${this.buildScripts()}`
+
+    return new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode(shellPre))
+        const reader = reactStream.getReader()
+        try {
+          for (; ;) {
+            const { done, value } = await reader.read()
+            if (done) break
+            controller.enqueue(value)
+          }
+        } catch (error) {
+          controller.error(error)
+          return
+        } finally {
+          reader.releaseLock()
+        }
+        controller.enqueue(encoder.encode(shellPost))
+        controller.close()
+      },
+    })
+  }
+
+  /**
+   * Buffered, client-only document used when SSR is disabled for the request.
+   * Emits an empty `#app` div for the client bundle to hydrate.
+   */
+  renderClientOnly(page: Page, head: string[]): string {
+    return this.buildShell(head)
+      + `<script data-page="${APP_ID}" type="application/json">${this.serialize(page)}</script><div id="${APP_ID}"></div>`
+      + this.buildScripts()
+  }
+
+  // Function replacements are required: a string replacement interprets `$$`,
+  // `$&`, `` $` `` and `$'` patterns, which would corrupt head/script content
+  // that legitimately contains a `$`.
+  private buildShell(head: string[]): string {
+    const headTags = head.join('\n')
+    return this.pre
+      .replace('@viteHead', () => this.manifest.getHeadTags())
+      .replace('@inertiaHead', () => headTags)
+  }
+
+  private buildScripts(): string {
+    return this.post.replace('@viteScripts', () => this.manifest.getScriptTags())
+  }
+
+  private serialize(page: Page): string {
+    return JSON.stringify(page).replace(/\//g, '\\/')
   }
 }

--- a/packages/inertia/src/services/template.service.ts
+++ b/packages/inertia/src/services/template.service.ts
@@ -38,29 +38,35 @@ export class TemplateService {
    */
   renderStream(page: Page, head: string[], reactStream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
     const encoder = new TextEncoder()
-    const shellPre = this.buildShell(head)
+    const shellPre = this.fillPlaceholders(this.pre, head)
       + `<script data-page="${APP_ID}" type="application/json">${this.serialize(page)}</script>`
       + `<div data-server-rendered="true" id="${APP_ID}">`
-    const shellPost = `</div>${this.buildScripts()}`
+    const shellPost = `</div>${this.fillPlaceholders(this.post, head)}`
 
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
     return new ReadableStream<Uint8Array>({
       async start(controller) {
         controller.enqueue(encoder.encode(shellPre))
-        const reader = reactStream.getReader()
+        reader = reactStream.getReader()
         try {
           for (; ;) {
             const { done, value } = await reader.read()
             if (done) break
             controller.enqueue(value)
           }
+          controller.enqueue(encoder.encode(shellPost))
+          controller.close()
         } catch (error) {
           controller.error(error)
-          return
         } finally {
           reader.releaseLock()
+          reader = undefined
         }
-        controller.enqueue(encoder.encode(shellPost))
-        controller.close()
+      },
+      // Forward a downstream cancellation (e.g. the client disconnects) up to the
+      // React render so it stops working on a response no one is reading.
+      cancel(reason) {
+        return reader?.cancel(reason) ?? reactStream.cancel(reason)
       },
     })
   }
@@ -70,23 +76,21 @@ export class TemplateService {
    * Emits an empty `#app` div for the client bundle to hydrate.
    */
   renderClientOnly(page: Page, head: string[]): string {
-    return this.buildShell(head)
+    return this.fillPlaceholders(this.pre, head)
       + `<script data-page="${APP_ID}" type="application/json">${this.serialize(page)}</script><div id="${APP_ID}"></div>`
-      + this.buildScripts()
+      + this.fillPlaceholders(this.post, head)
   }
 
-  // Function replacements are required: a string replacement interprets `$$`,
-  // `$&`, `` $` `` and `$'` patterns, which would corrupt head/script content
-  // that legitimately contains a `$`.
-  private buildShell(head: string[]): string {
-    const headTags = head.join('\n')
-    return this.pre
+  // Fill the document placeholders in a template segment. Function replacements
+  // are required: a string replacement interprets `$$`, `$&`, `` $` `` and `$'`
+  // patterns, which would corrupt head/script content that legitimately contains
+  // a `$`. Each token is filled wherever it appears (a token absent from the
+  // segment is a no-op), so placement of @viteHead/@viteScripts doesn't matter.
+  private fillPlaceholders(segment: string, head: string[]): string {
+    return segment
+      .replace('@inertiaHead', () => head.join('\n'))
       .replace('@viteHead', () => this.manifest.getHeadTags())
-      .replace('@inertiaHead', () => headTags)
-  }
-
-  private buildScripts(): string {
-    return this.post.replace('@viteScripts', () => this.manifest.getScriptTags())
+      .replace('@viteScripts', () => this.manifest.getScriptTags())
   }
 
   private serialize(page: Page): string {

--- a/packages/inertia/src/ssr.ts
+++ b/packages/inertia/src/ssr.ts
@@ -21,12 +21,18 @@ import type { InertiaSsrResult } from './types'
 // `@inertiajs/react` does not re-export its `InertiaAppProps` type, so derive it
 // from the `App` component's own parameters.
 type AppProps = Parameters<typeof App>[0]
+
+/** A page component for `TProps`, or a module namespace whose `default` is one. */
+type ResolvedPage<TProps> = ComponentType<TProps> | { default: ComponentType<TProps> }
+
 /**
- * A resolved Inertia page component. Concretely typed (rather than reusing
- * `@inertiajs/react`'s `ResolvedComponent`, which is `ComponentType<any>`) so no
- * `any` leaks out of the resolver into the rest of the bundle.
+ * The resolver's return type, keyed on whether a props type argument was supplied:
+ * with none (`TProps` defaults to `unknown`) it stays opaque — matching what
+ * `import.meta.glob` yields — and with one it is the typed component/module.
  */
-type PageComponent = ComponentType<Record<string, unknown>>
+type ResolverReturn<TProps> = [unknown] extends [TProps]
+  ? unknown
+  : ResolvedPage<TProps> | Promise<ResolvedPage<TProps>>
 
 /** Unwrap a module namespace's `default` export, leaving a bare component as-is. */
 function unwrapDefault(module: unknown): unknown {
@@ -40,19 +46,21 @@ function unwrapDefault(module: unknown): unknown {
  * (a `memo`/`forwardRef`/`lazy` exotic component). This narrows the opaque value a
  * dynamic import yields without admitting `any`.
  */
-function isPageComponent(value: unknown): value is PageComponent {
+function isPageComponent<TProps>(value: unknown): value is ComponentType<TProps> {
   return typeof value === 'function' || (typeof value === 'object' && value !== null)
 }
 
-export interface CreateInertiaSsrAppOptions {
+export interface CreateInertiaSsrAppOptions<TProps = unknown> {
   /**
    * Resolve a page by name. Typically backed by `import.meta.glob`, whose modules
    * are opaque (`unknown`) — the returned value is unwrapped (a `default` export is
    * taken when present) and narrowed to a component at runtime, so an invalid
-   * resolver result fails loudly rather than rendering nothing. May return a
-   * component, a module namespace, or a promise of either.
+   * resolver result fails loudly rather than rendering nothing. Pass a props type
+   * argument to {@link createInertiaSsrApp} to type the resolver's return.
    */
-  resolve: (name: string) => unknown
+  // `NoInfer` keeps `TProps` pinned to its explicit type argument (or the
+  // `unknown` default) instead of being widened back out of the resolver return.
+  resolve: (name: string) => ResolverReturn<NoInfer<TProps>>
   /**
    * Optional wrapper for application-level providers (theme, store, i18n, …).
    * Receives the Inertia `App` component and its props; return the React tree to
@@ -77,11 +85,13 @@ export interface InertiaSsrApp {
  * progressively. Head tags rendered inside a *suspended* boundary are not
  * captured; use Stratal's server-side SEO (`ctx.seo()`) for `<head>` metadata.
  */
-export function createInertiaSsrApp(options: CreateInertiaSsrAppOptions): InertiaSsrApp {
-  const resolveComponent = (name: string): Promise<PageComponent> =>
+export function createInertiaSsrApp<TProps = unknown>(
+  options: CreateInertiaSsrAppOptions<TProps>,
+): InertiaSsrApp {
+  const resolveComponent = (name: string): Promise<ComponentType<TProps>> =>
     Promise.resolve(options.resolve(name)).then((module) => {
       const component = unwrapDefault(module)
-      if (!isPageComponent(component)) {
+      if (!isPageComponent<TProps>(component)) {
         throw new ApplicationError(`[stratal:inertia] resolve("${name}") did not return a React component.`)
       }
       return component

--- a/packages/inertia/src/ssr.ts
+++ b/packages/inertia/src/ssr.ts
@@ -1,0 +1,85 @@
+/**
+ * Server-side rendering entry for Stratal Inertia.
+ *
+ * Provides {@link createInertiaSsrApp}, which encapsulates React 19 streaming SSR
+ * (`renderToReadableStream`) and Inertia's head collection, returning the
+ * `render(page)` function the `InertiaModule` SSR bundle option expects.
+ *
+ * This entry pulls React + `react-dom/server` into the worker SSR bundle and is
+ * intentionally separate from the client (`./react`) and server (`.`) entries.
+ *
+ * @packageDocumentation
+ */
+
+import type { HeadManagerTitleCallback, Page } from '@inertiajs/core'
+import { App } from '@inertiajs/react'
+import { type ComponentType, type ReactNode, createElement } from 'react'
+import { renderToReadableStream } from 'react-dom/server'
+import type { InertiaSsrResult } from './types'
+
+// `@inertiajs/react` does not re-export its `InertiaAppProps` type, so derive it
+// from the `App` component's own parameters.
+type AppProps = Parameters<typeof App>[0]
+/**
+ * A resolved Inertia page component. Concretely typed (rather than reusing
+ * `@inertiajs/react`'s `ResolvedComponent`, which is `ComponentType<any>`) so no
+ * `any` leaks through the resolver into the rest of the bundle.
+ */
+type PageComponent = ComponentType<Record<string, unknown>>
+type ResolvedModule = PageComponent | { default: PageComponent }
+
+export interface CreateInertiaSsrAppOptions {
+  /**
+   * Resolve a page component by name. Typically backed by `import.meta.glob`.
+   * May return the component directly or a module whose `default` is the component.
+   */
+  resolve: (name: string) => ResolvedModule | Promise<ResolvedModule>
+  /**
+   * Optional wrapper for application-level providers (theme, store, i18n, …).
+   * Receives the Inertia `App` component and its props; return the React tree to
+   * render. When omitted, `App` is rendered directly.
+   */
+  setup?: (args: { App: typeof App; props: AppProps }) => ReactNode
+  /**
+   * Optional document-title callback (Inertia `title`), applied to page titles.
+   */
+  title?: HeadManagerTitleCallback
+}
+
+export interface InertiaSsrApp {
+  render(page: Page): Promise<InertiaSsrResult>
+}
+
+/**
+ * Build a streaming Inertia SSR handler.
+ *
+ * The returned `render(page)` resolves once React's shell is ready — at which
+ * point Inertia's `<Head>` tags have been collected — and streams the body
+ * progressively. Head tags rendered inside a *suspended* boundary are not
+ * captured; use Stratal's server-side SEO (`ctx.seo()`) for `<head>` metadata.
+ */
+export function createInertiaSsrApp(options: CreateInertiaSsrAppOptions): InertiaSsrApp {
+  const resolveComponent = (name: string): Promise<PageComponent> =>
+    Promise.resolve(options.resolve(name)).then((mod) =>
+      'default' in mod ? mod.default : mod,
+    )
+
+  return {
+    async render(page: Page): Promise<InertiaSsrResult> {
+      let head: string[] = []
+      const initialComponent = await resolveComponent(page.component)
+      const props: AppProps = {
+        initialPage: page,
+        initialComponent,
+        resolveComponent,
+        titleCallback: options.title,
+        onHeadUpdate: (elements: string[]) => { head = elements },
+      }
+      const app = options.setup
+        ? options.setup({ App, props })
+        : createElement(App, props)
+      const stream = await renderToReadableStream(app)
+      return { head, stream }
+    },
+  }
+}

--- a/packages/inertia/src/ssr.ts
+++ b/packages/inertia/src/ssr.ts
@@ -12,15 +12,41 @@
  */
 
 import type { HeadManagerTitleCallback, Page } from '@inertiajs/core'
+// Import `App` as a runtime value only — never reference its *type*
+// (`typeof App`, `Parameters<typeof App>`, `ComponentProps<typeof App>`, …) in
+// this module's exported surface. Any such reference makes the emitted `.d.mts`
+// re-export `import { App } from '@inertiajs/react'`, which pulls Inertia's whole
+// type graph into resolution the moment a consumer imports this SSR entry. That
+// eagerly evaluates `@inertiajs/core`'s config-driven types (`FlashData`,
+// `SharedPageProps`, derived from its `InertiaConfig` interface) before a
+// consumer's own `declare module '@inertiajs/core'` augmentation has been
+// applied, caching the un-augmented defaults — so `usePage().flash` /
+// `usePage().props` degrade to `unknown` at call sites. Typing this entry's
+// surface structurally (below) keeps `@inertiajs/react` out of the generated
+// declarations and avoids the hazard.
 import { App } from '@inertiajs/react'
 import { type ComponentType, type ReactNode, createElement } from 'react'
 import { renderToReadableStream } from 'react-dom/server'
 import { ApplicationError } from 'stratal/errors'
 import type { InertiaSsrResult } from './types'
 
-// `@inertiajs/react` does not re-export its `InertiaAppProps` type, so derive it
-// from the `App` component's own parameters.
-type AppProps = Parameters<typeof App>[0]
+/**
+ * The props Inertia's `App` component receives, reconstructed locally from
+ * `@inertiajs/core` + React types. Mirrors `@inertiajs/react`'s `InertiaAppProps`
+ * without importing it — see the `App` import note above for why that matters.
+ */
+interface AppProps {
+  initialPage: Page
+  // `ComponentType<any>` mirrors Inertia's own `ReactComponent` (page components
+  // are resolved opaquely), keeping the resolver's `ComponentType<TProps>` output
+  // assignable here without coupling to `@inertiajs/react`'s exported types.
+  // oxlint-disable-next-line typescript/no-explicit-any
+  initialComponent?: ComponentType<any>
+  // oxlint-disable-next-line typescript/no-explicit-any
+  resolveComponent?: (name: string, page?: Page) => ComponentType<any> | Promise<ComponentType<any>>
+  titleCallback?: HeadManagerTitleCallback
+  onHeadUpdate?: (elements: string[]) => void
+}
 
 /** A page component for `TProps`, or a module namespace whose `default` is one. */
 type ResolvedPage<TProps> = ComponentType<TProps> | { default: ComponentType<TProps> }
@@ -66,7 +92,7 @@ export interface CreateInertiaSsrAppOptions<TProps = unknown> {
    * Receives the Inertia `App` component and its props; return the React tree to
    * render. When omitted, `App` is rendered directly.
    */
-  setup?: (args: { App: typeof App; props: AppProps }) => ReactNode
+  setup?: (args: { App: ComponentType<AppProps>; props: AppProps }) => ReactNode
   /**
    * Optional document-title callback (Inertia `title`), applied to page titles.
    */

--- a/packages/inertia/src/ssr.ts
+++ b/packages/inertia/src/ssr.ts
@@ -15,6 +15,7 @@ import type { HeadManagerTitleCallback, Page } from '@inertiajs/core'
 import { App } from '@inertiajs/react'
 import { type ComponentType, type ReactNode, createElement } from 'react'
 import { renderToReadableStream } from 'react-dom/server'
+import { ApplicationError } from 'stratal/errors'
 import type { InertiaSsrResult } from './types'
 
 // `@inertiajs/react` does not re-export its `InertiaAppProps` type, so derive it
@@ -23,17 +24,35 @@ type AppProps = Parameters<typeof App>[0]
 /**
  * A resolved Inertia page component. Concretely typed (rather than reusing
  * `@inertiajs/react`'s `ResolvedComponent`, which is `ComponentType<any>`) so no
- * `any` leaks through the resolver into the rest of the bundle.
+ * `any` leaks out of the resolver into the rest of the bundle.
  */
 type PageComponent = ComponentType<Record<string, unknown>>
-type ResolvedModule = PageComponent | { default: PageComponent }
+
+/** Unwrap a module namespace's `default` export, leaving a bare component as-is. */
+function unwrapDefault(module: unknown): unknown {
+  return typeof module === 'object' && module !== null && 'default' in module
+    ? (module as { default: unknown }).default
+    : module
+}
+
+/**
+ * A React component is either a function (function/class component) or an object
+ * (a `memo`/`forwardRef`/`lazy` exotic component). This narrows the opaque value a
+ * dynamic import yields without admitting `any`.
+ */
+function isPageComponent(value: unknown): value is PageComponent {
+  return typeof value === 'function' || (typeof value === 'object' && value !== null)
+}
 
 export interface CreateInertiaSsrAppOptions {
   /**
-   * Resolve a page component by name. Typically backed by `import.meta.glob`.
-   * May return the component directly or a module whose `default` is the component.
+   * Resolve a page by name. Typically backed by `import.meta.glob`, whose modules
+   * are opaque (`unknown`) — the returned value is unwrapped (a `default` export is
+   * taken when present) and narrowed to a component at runtime, so an invalid
+   * resolver result fails loudly rather than rendering nothing. May return a
+   * component, a module namespace, or a promise of either.
    */
-  resolve: (name: string) => ResolvedModule | Promise<ResolvedModule>
+  resolve: (name: string) => unknown
   /**
    * Optional wrapper for application-level providers (theme, store, i18n, …).
    * Receives the Inertia `App` component and its props; return the React tree to
@@ -60,9 +79,13 @@ export interface InertiaSsrApp {
  */
 export function createInertiaSsrApp(options: CreateInertiaSsrAppOptions): InertiaSsrApp {
   const resolveComponent = (name: string): Promise<PageComponent> =>
-    Promise.resolve(options.resolve(name)).then((mod) =>
-      'default' in mod ? mod.default : mod,
-    )
+    Promise.resolve(options.resolve(name)).then((module) => {
+      const component = unwrapDefault(module)
+      if (!isPageComponent(component)) {
+        throw new ApplicationError(`[stratal:inertia] resolve("${name}") did not return a React component.`)
+      }
+      return component
+    })
 
   return {
     async render(page: Page): Promise<InertiaSsrResult> {

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -1,4 +1,4 @@
-import type { InertiaAppSSRResponse, Page, SharedPageProps } from '@inertiajs/core'
+import type { Page, SharedPageProps } from '@inertiajs/core'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { MessageKeys } from 'stratal/i18n'
 import type { RouterContext } from 'stratal/router'
@@ -47,8 +47,15 @@ export interface InertiaRenderOptions {
   status?: ContentfulStatusCode
 }
 
-// Use InertiaAppSSRResponse from @inertiajs/core — { head: string[]; body: string }
-export type InertiaSsrResult = InertiaAppSSRResponse
+/**
+ * Streaming SSR render result. `head` carries the document `<head>` tags Inertia
+ * collected during the synchronous shell render (known once the shell is ready);
+ * `stream` is React's `renderToReadableStream` output, piped into the `#app` body.
+ */
+export interface InertiaSsrResult {
+  head: string[]
+  stream: ReadableStream<Uint8Array>
+}
 
 export interface InertiaSsrBundle {
   render(page: Page): Promise<InertiaSsrResult>

--- a/packages/inertia/tsdown.config.ts
+++ b/packages/inertia/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'src/index.ts',
     'src/vite.ts',
     'src/react.ts',
+    'src/ssr.ts',
     'src/seo-runtime.ts',
     'src/testing.ts',
     'src/quarry.ts',


### PR DESCRIPTION
## Summary
Switch Inertia SSR from buffered `renderToString` to streaming `renderToReadableStream`, so the document shell flushes immediately and `React.lazy`/`Suspense` boundaries stream in progressively (lower TTFB, no full-document buffering). Adds a `createInertiaSsrApp` helper, memoizes manifest tags, and removes the silent client-side fallback so SSR errors surface.

## How to Test
- `yarn workspace @stratal/inertia test` — 219 pass (incl. progressive-streaming guard)
- `yarn workspace @stratal/inertia build` — confirm new `./ssr` export is emitted
- Load a streaming SSR route; response has no `Content-Length` (chunked `ReadableStream`) while the Inertia XHR/JSON path still sets it
- On a `React.lazy` route, confirm the shell flushes first, then Suspense `<template>` + reveal script stream in after
- `quarry inertia:install` scaffolds `src/inertia/ssr.tsx` wired to `createInertiaSsrApp`

## Breaking Changes
- The SSR bundle contract changed: `render(page)` now returns `{ head, stream }` (was `{ head, body }`), and there is no silent client-side fallback — SSR failures surface as errors.
- Migrate `src/inertia/ssr.tsx` to the new helper:

  ```tsx
  import { createInertiaSsrApp } from '@stratal/inertia/ssr'

  export const { render } = createInertiaSsrApp({
    resolve: async (name) => {
      const pages = import.meta.glob('./pages/**/*.tsx')
      const page = await pages[`./pages/${name}.tsx`]?.()
      if (!page) throw new Error(`Page not found: ${name}`)
      return page
    },
  })

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming SSR with React 19 for progressive server-rendered content
  * Installer now scaffolds an SSR entry and auto-wires SSR into new projects
  * Per-route and global SSR disabling options

* **Documentation**
  * README updated with Streaming SSR setup and usage guidance

* **Bug Fixes**
  * SSR errors now surface as failures (no silent client-side fallback)

* **Refactor**
  * Manifest tag generation memoized for improved performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->