### PR TITLE
feat(events): emit entity mutation events with full entity snapshots

### DIFF
--- a/.changeset/entity-mutation-events-core.md
+++ b/.changeset/entity-mutation-events-core.md
@@ -1,0 +1,7 @@
+---
+"stratal": patch
+---
+
+Add `hasListeners()` to the event registry for checking whether any handler matches an event
+
+Uses the same pattern matching as `emit()` (exact, model wildcard, operation wildcard, phase wildcard), letting emitters skip expensive payload construction when nobody is listening.

--- a/.changeset/entity-mutation-events-framework.md
+++ b/.changeset/entity-mutation-events-framework.md
@@ -1,0 +1,11 @@
+---
+"@stratal/framework": patch
+---
+
+Emit entity mutation events with full entity snapshots from the database layer
+
+### Details
+
+- New typed events: `entity.{Model}.created` (`{ after }`), `entity.{Model}.updated` (`{ before, after }`), and `entity.{Model}.deleted` (`{ before }`), plus wildcard subscriptions (`entity.{Model}`, `entity.{verb}`, `entity`).
+- Unlike the existing `before.*`/`after.*` events (raw query args/result), entity events carry full entity snapshots, with the pre-mutation snapshot loaded inside the mutation's transaction.
+- Listener-driven cost: snapshots are only loaded when a matching subscription exists, so models nobody observes pay nothing. A global `entity` wildcard makes every model pay the pre-read — subscribe per model when cost matters.

--- a/.changeset/inertia-dev-inspector-port-inertia.md
+++ b/.changeset/inertia-dev-inspector-port-inertia.md
@@ -1,0 +1,7 @@
+---
+"@stratal/inertia": patch
+---
+
+Add `--inspector-port` option to `inertia:dev` for configuring the worker debugger inspector port
+
+Set a distinct port per worker to avoid `EADDRINUSE` when running multiple Inertia workers concurrently, or pass `false` to disable the inspector entirely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Per-package contributor rules: `packages/<name>/CLAUDE.md` — auto-load when wo
 - Don't hand-edit `packages/*/package.json` `exports` — `tsdown` regenerates on build. Add new sub-paths via the package's `tsdown.config.ts` `entry` list. For an alias (path A exposed at name B) use `customExports`.
 - Keep `experimentalDecorators` + `emitDecoratorMetadata` on (needed by the DI decorator system).
 - DI tokens: `Symbol.for('stratal:...')` in each package's `tokens.ts`. Never strings.
-- Inline type imports enforced (`consistent-type-imports`). Leading-underscore for unused vars.
+- Type-only imports must be marked `type` (`consistent-type-imports`). Both `import type { X }` and `import { type X }` satisfy the rule — `import type { X }` is the prevailing style; don't flag either form. Leading-underscore for unused vars.
 - `oxlint` lints. Husky + lint-staged auto-fixes staged `.ts/.mts` on commit. Don't pass `--no-verify`.
 - Shared build helpers in `tsdown.base.ts` (`baseConfig`, `withTypesExports`). Touching this file affects every package — typecheck and build all on changes.
 - Build target tsconfig is `tsconfig.build.json` per package (separate from the editor `tsconfig.json`). Don't point `tsdown` at the editor config.

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -325,6 +325,8 @@ export class Application {
     return {
       getLocale: () => locale,
       setLocale: () => { /* no-op */ },
+      // Non-HTTP scopes have no request headers
+      header: () => undefined,
       // Inside runInRequestScope the active container is the request-scoped child
       // (set in AsyncLocalStorage); return it so request-scoped providers resolve
       // against the scope, not the global container.

--- a/packages/core/src/di/__tests__/container.spec.ts
+++ b/packages/core/src/di/__tests__/container.spec.ts
@@ -318,6 +318,36 @@ describe('Container', () => {
       // The provider IS registered; a failure constructing it is a real error.
       expect(() => container.tryResolve(THROWS_TOKEN)).toThrow('boom')
     })
+
+    it('should return undefined for a request-scoped provider outside a request scope', () => {
+      container.register(REQUEST_SCOPED_TOKEN, RequestScopedService)
+
+      // Optional request-scoped dependency outside a request = absent, not an
+      // error — mirrors `@inject(..., { isOptional: true })` semantics.
+      expect(container.tryResolve(REQUEST_SCOPED_TOKEN)).toBeUndefined()
+    })
+
+    it('should resolve a request-scoped provider inside a request scope', async () => {
+      container.register(REQUEST_SCOPED_TOKEN, RequestScopedService)
+      const routerContext = { getContainer: () => container } as unknown as RouterContext
+
+      await container.runInRequestScope(routerContext, (req) => {
+        expect(req.tryResolve(REQUEST_SCOPED_TOKEN)).toBeInstanceOf(RequestScopedService)
+      })
+    })
+
+    it('should return undefined for an alias to a request-scoped provider outside a request scope', () => {
+      container.register(REQUEST_SCOPED_TOKEN, RequestScopedService)
+      container.registerExisting(ALIAS_TOKEN, REQUEST_SCOPED_TOKEN)
+
+      expect(container.tryResolve(ALIAS_TOKEN)).toBeUndefined()
+    })
+
+    it('should return undefined for an unregistered request-scoped class token outside a request scope', () => {
+      // Auto-resolvable constructor: scope comes from decorator metadata, not a
+      // registration — must behave the same on the first call as on later ones.
+      expect(container.tryResolve(RequestScopedService)).toBeUndefined()
+    })
   })
 
 })

--- a/packages/core/src/di/__tests__/container.spec.ts
+++ b/packages/core/src/di/__tests__/container.spec.ts
@@ -3,6 +3,7 @@ import type { RouterContext } from '../../router/router-context'
 import { Container } from '../container'
 import { ContainerError } from '../container.error'
 import { inject, Request, Transient } from '../decorators'
+import { lazy } from '../lazy'
 import { CONTAINER_TOKEN, DI_TOKENS } from '../tokens'
 
 // Test services
@@ -334,6 +335,14 @@ describe('Container', () => {
       await container.runInRequestScope(routerContext, (req) => {
         expect(req.tryResolve(REQUEST_SCOPED_TOKEN)).toBeInstanceOf(RequestScopedService)
       })
+    })
+
+    it('should return undefined for a lazily-registered request-scoped provider outside a request scope', () => {
+      container.register(REQUEST_SCOPED_TOKEN, lazy(() => RequestScopedService))
+
+      // Lazy registrations derive their scope from decorator metadata at
+      // resolution time — tryResolve must see the same scope and stay silent.
+      expect(container.tryResolve(REQUEST_SCOPED_TOKEN)).toBeUndefined()
     })
 
     it('should return undefined for an alias to a request-scoped provider outside a request scope', () => {

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -186,6 +186,11 @@ export class Container {
     // must surface — swallowing it would silently inject `undefined` and turn a
     // bug into a baffling downstream failure.
     if (!this.isResolvable(realToken)) return undefined
+
+    // An optional request-scoped dependency outside a request scope is absent,
+    // not an error — mirrors `@inject(..., { isOptional: true })` semantics.
+    if (!this.isRequestScoped && this.scopeForToken(realToken) === Scope.Request) return undefined
+
     return this.resolve(realToken)
   }
 
@@ -298,6 +303,24 @@ export class Container {
     // A bare constructor token that is auto-resolvable (carries DI metadata).
     if (typeof token === 'function' && getClassMetadata(token as Constructor)) {
       return token as unknown as Constructor
+    }
+    return undefined
+  }
+
+  /**
+   * The effective scope a token would resolve with, following alias
+   * registrations. Bare constructor tokens fall back to their decorator
+   * metadata — the same scope {@link resolve} uses when auto-registering.
+   */
+  private scopeForToken(token: InjectionToken): Scope | undefined {
+    const reg = this.findRegistration(token)
+    if (reg) {
+      if (reg.kind === 'class') return reg.scope
+      if (reg.kind === 'alias') return this.scopeForToken(reg.target)
+      return undefined
+    }
+    if (typeof token === 'function') {
+      return getClassMetadata(token as Constructor)?.scope
     }
     return undefined
   }

--- a/packages/core/src/di/container.ts
+++ b/packages/core/src/di/container.ts
@@ -317,6 +317,8 @@ export class Container {
     if (reg) {
       if (reg.kind === 'class') return reg.scope
       if (reg.kind === 'alias') return this.scopeForToken(reg.target)
+      // Same scope derivation `resolveRegistration` uses for lazy registrations
+      if (reg.kind === 'lazy') return getClassMetadata(reg.factory())?.scope ?? Scope.Transient
       return undefined
     }
     if (typeof token === 'function') {

--- a/packages/core/src/di/types.ts
+++ b/packages/core/src/di/types.ts
@@ -17,4 +17,9 @@ export type ExtensionDecorator<T> = (service: T, container: ContainerLike) => T
 
 export interface ContainerLike {
   resolve<T>(token: InjectionToken<T>): T
+  /**
+   * Resolves an optional dependency: `undefined` when nothing is registered,
+   * or when a request-scoped provider is requested outside a request scope.
+   */
+  tryResolve<T>(token: InjectionToken<T>): T | undefined
 }

--- a/packages/core/src/events/__tests__/event-registry.spec.ts
+++ b/packages/core/src/events/__tests__/event-registry.spec.ts
@@ -1,0 +1,53 @@
+import { createMock } from '@stratal/testing/mocks'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LoggerService } from '../../logger'
+import { EventRegistry } from '../event-registry'
+
+describe('EventRegistry', () => {
+  let registry: EventRegistry
+
+  beforeEach(() => {
+    registry = new EventRegistry(
+      createMock<ExecutionContext>(),
+      createMock<LoggerService>()
+    )
+  })
+
+  describe('hasListeners', () => {
+    it('returns false when no handler is registered', () => {
+      expect(registry.hasListeners('entity.Post.updated')).toBe(false)
+    })
+
+    it('returns true for an exact-match handler', () => {
+      registry.on('entity.Post.updated', vi.fn())
+      expect(registry.hasListeners('entity.Post.updated')).toBe(true)
+    })
+
+    it('matches model wildcard handlers (entity.Post)', () => {
+      registry.on('entity.Post', vi.fn())
+      expect(registry.hasListeners('entity.Post.updated')).toBe(true)
+    })
+
+    it('matches action wildcard handlers (entity.updated)', () => {
+      registry.on('entity.updated', vi.fn())
+      expect(registry.hasListeners('entity.Post.updated')).toBe(true)
+    })
+
+    it('matches phase wildcard handlers (entity)', () => {
+      registry.on('entity', vi.fn())
+      expect(registry.hasListeners('entity.Post.updated')).toBe(true)
+    })
+
+    it('does not match handlers registered for other models', () => {
+      registry.on('entity.User.updated', vi.fn())
+      expect(registry.hasListeners('entity.Post.updated')).toBe(false)
+    })
+
+    it('returns false after the only handler is removed', () => {
+      const handler = vi.fn()
+      registry.on('entity.Post.updated', handler)
+      registry.off('entity.Post.updated', handler)
+      expect(registry.hasListeners('entity.Post.updated')).toBe(false)
+    })
+  })
+})

--- a/packages/core/src/events/event-registry.ts
+++ b/packages/core/src/events/event-registry.ts
@@ -90,6 +90,10 @@ export class EventRegistry implements IEventRegistry {
     this.logger.debug('Event handler unregistered', { event })
   }
 
+  hasListeners(event: EventName): boolean {
+    return this.findMatchingHandlers(event).length > 0
+  }
+
   once<E extends EventName>(event: E, handler: EventHandler<E>, options?: EventOptions): void {
     const wrappedHandler = (async (context: EventContext<E>) => {
       await handler(context)

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -141,6 +141,14 @@ export interface IEventRegistry {
     handler: EventHandler<E>,
     options?: EventOptions
   ): void
+
+  /**
+   * Whether any registered handler matches the event, using the same
+   * pattern matching as `emit()` (exact, model wildcard, operation
+   * wildcard, phase wildcard). Lets emitters skip expensive payload
+   * construction when nobody is listening.
+   */
+  hasListeners(event: EventName): boolean
 }
 
 // ============================================================================

--- a/packages/framework/src/database/event-types.ts
+++ b/packages/framework/src/database/event-types.ts
@@ -209,7 +209,15 @@ interface EntityModelWildcardContext<M extends ModelName> {
   after: GetEntity<M> | undefined
 }
 
-/** Context for verb/global wildcard subscriptions (e.g. "entity.updated", "entity") */
+/** Context for verb wildcard subscriptions (e.g. "entity.updated") */
+interface EntityVerbWildcardContext<V extends EntityMutationVerb> {
+  model: ModelName
+  action: V
+  before: V extends 'created' ? undefined : unknown
+  after: V extends 'deleted' ? undefined : unknown
+}
+
+/** Context for the global wildcard subscription ("entity") */
 interface EntityWildcardContext {
   model: ModelName
   action: EntityMutationVerb
@@ -222,6 +230,7 @@ type EntityEventContext<E extends string> =
   : E extends `entity.${infer M extends ModelName}.updated` ? EntityUpdatedEventContext<M>
   : E extends `entity.${infer M extends ModelName}.deleted` ? EntityDeletedEventContext<M>
   : E extends `entity.${infer M extends ModelName}` ? EntityModelWildcardContext<M>
+  : E extends `entity.${infer V extends EntityMutationVerb}` ? EntityVerbWildcardContext<V>
   : EntityWildcardContext
 
 /**

--- a/packages/framework/src/database/event-types.ts
+++ b/packages/framework/src/database/event-types.ts
@@ -140,6 +140,98 @@ export type GetResult<M extends ModelName, O extends DatabaseOperation> =
   _ExtractResult<InferAnySchema, M, O> extends never ? unknown : _ExtractResult<InferAnySchema, M, O>
 
 // ============================================================================
+// Entity Mutation Events
+// ============================================================================
+
+/**
+ * Verb suffix for entity-mutation events (`entity.{Model}.{verb}`).
+ */
+export type EntityMutationVerb = 'created' | 'updated' | 'deleted'
+
+/**
+ * Entity-mutation event names with all supported patterns.
+ *
+ * Unlike `before.*`/`after.*` (raw query args/result), entity events carry
+ * full entity snapshots: `created` has `after`, `updated` has `before` and
+ * `after`, `deleted` has `before`. The pre-mutation snapshot is loaded inside
+ * the mutation's transaction, and only when a listener matches — a wildcard
+ * subscription (`entity`) makes every model pay that pre-read, so subscribe
+ * per model when cost matters.
+ */
+export type EntityEventName =
+  | `entity.${ModelName}.${EntityMutationVerb}`
+  | `entity.${ModelName}`
+  | `entity.${EntityMutationVerb}`
+  | 'entity'
+
+/**
+ * Distributive helper — resolves the full entity shape for a model.
+ */
+type _ExtractEntity<S, M extends string> =
+  S extends SchemaDef
+  ? M extends Extract<keyof S['models'], string>
+  ? ModelResult<S, M>
+  : never
+  : never
+
+/**
+ * Full entity snapshot type for a model, across all connections' schemas.
+ */
+export type GetEntity<M extends ModelName> =
+  _ExtractEntity<InferAnySchema, M> extends never ? unknown : _ExtractEntity<InferAnySchema, M>
+
+interface EntityCreatedEventContext<M extends ModelName> {
+  model: M
+  action: 'created'
+  before: undefined
+  after: GetEntity<M>
+}
+
+interface EntityUpdatedEventContext<M extends ModelName> {
+  model: M
+  action: 'updated'
+  before: GetEntity<M>
+  after: GetEntity<M>
+}
+
+interface EntityDeletedEventContext<M extends ModelName> {
+  model: M
+  action: 'deleted'
+  before: GetEntity<M>
+  after: undefined
+}
+
+/** Context for model wildcard subscriptions (e.g. "entity.User") */
+interface EntityModelWildcardContext<M extends ModelName> {
+  model: M
+  action: EntityMutationVerb
+  before: GetEntity<M> | undefined
+  after: GetEntity<M> | undefined
+}
+
+/** Context for verb/global wildcard subscriptions (e.g. "entity.updated", "entity") */
+interface EntityWildcardContext {
+  model: ModelName
+  action: EntityMutationVerb
+  before: unknown
+  after: unknown
+}
+
+type EntityEventContext<E extends string> =
+  E extends `entity.${infer M extends ModelName}.created` ? EntityCreatedEventContext<M>
+  : E extends `entity.${infer M extends ModelName}.updated` ? EntityUpdatedEventContext<M>
+  : E extends `entity.${infer M extends ModelName}.deleted` ? EntityDeletedEventContext<M>
+  : E extends `entity.${infer M extends ModelName}` ? EntityModelWildcardContext<M>
+  : EntityWildcardContext
+
+/**
+ * Mapped type producing all entity-mutation event name → context pairs.
+ */
+export type EntityEvents = {
+  [E in EntityEventName]: EntityEventContext<E>
+}
+
+// ============================================================================
 // Parse Event String
 // ============================================================================
 
@@ -261,5 +353,5 @@ export type DatabaseEvents = {
 // ============================================================================
 
 declare module 'stratal/events' {
-  interface CustomEventRegistry extends DatabaseEvents { }
+  interface CustomEventRegistry extends DatabaseEvents, EntityEvents { }
 }

--- a/packages/framework/src/database/plugins/__tests__/event-emitter.plugin.spec.ts
+++ b/packages/framework/src/database/plugins/__tests__/event-emitter.plugin.spec.ts
@@ -1,0 +1,182 @@
+import { createMock, type DeepMocked } from '@stratal/testing/mocks'
+import type { OperationNode, QueryId } from 'kysely'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IEventRegistry } from 'stratal/events'
+import { EventEmitterPlugin } from '../event-emitter.plugin'
+
+type BeforeHookArgs = Parameters<NonNullable<NonNullable<EventEmitterPlugin['onEntityMutation']>['beforeEntityMutation']>>[0]
+type AfterHookArgs = Parameters<NonNullable<NonNullable<EventEmitterPlugin['onEntityMutation']>['afterEntityMutation']>>[0]
+
+describe('EventEmitterPlugin entity mutation events', () => {
+  let registry: DeepMocked<IEventRegistry>
+  let plugin: EventEmitterPlugin
+
+  const queryId = createMock<QueryId>()
+  const queryNode = createMock<OperationNode>()
+  const client = createMock<BeforeHookArgs['client']>()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    registry = createMock<IEventRegistry>()
+    registry.emit.mockResolvedValue(undefined)
+    plugin = new EventEmitterPlugin({ eventRegistry: registry })
+  })
+
+  function beforeArgs(overrides: Partial<BeforeHookArgs> = {}): BeforeHookArgs {
+    return {
+      model: 'Post',
+      action: 'update',
+      queryNode,
+      queryId,
+      loadBeforeMutationEntities: vi.fn().mockResolvedValue([{ id: '1', title: 'old' }]),
+      client,
+      ...overrides,
+    }
+  }
+
+  function afterArgs(overrides: Partial<AfterHookArgs> = {}): AfterHookArgs {
+    return {
+      model: 'Post',
+      action: 'update',
+      queryNode,
+      queryId,
+      loadAfterMutationEntities: vi.fn().mockResolvedValue([{ id: '1', title: 'new' }]),
+      beforeMutationEntities: [{ id: '1', title: 'old' }],
+      client,
+      ...overrides,
+    }
+  }
+
+  describe('beforeEntityMutation', () => {
+    it('loads before-entities for update when a listener exists', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = beforeArgs()
+
+      await plugin.onEntityMutation.beforeEntityMutation!(args)
+
+      expect(registry.hasListeners).toHaveBeenCalledWith('entity.Post.updated')
+      expect(args.loadBeforeMutationEntities).toHaveBeenCalledOnce()
+    })
+
+    it('does NOT load before-entities when no listener exists', async () => {
+      registry.hasListeners.mockReturnValue(false)
+      const args = beforeArgs()
+
+      await plugin.onEntityMutation.beforeEntityMutation!(args)
+
+      expect(args.loadBeforeMutationEntities).not.toHaveBeenCalled()
+    })
+
+    it('does NOT load before-entities for create (no prior state)', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = beforeArgs({ action: 'create' })
+
+      await plugin.onEntityMutation.beforeEntityMutation!(args)
+
+      expect(args.loadBeforeMutationEntities).not.toHaveBeenCalled()
+    })
+
+    it('loads before-entities for delete when a listener exists', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = beforeArgs({ action: 'delete' })
+
+      await plugin.onEntityMutation.beforeEntityMutation!(args)
+
+      expect(registry.hasListeners).toHaveBeenCalledWith('entity.Post.deleted')
+      expect(args.loadBeforeMutationEntities).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('afterEntityMutation', () => {
+    it('emits entity.{Model}.updated with before/after for each entity', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = afterArgs()
+
+      await plugin.onEntityMutation.afterEntityMutation!(args)
+
+      expect(registry.emit).toHaveBeenCalledExactlyOnceWith('entity.Post.updated', {
+        model: 'Post',
+        action: 'updated',
+        before: { id: '1', title: 'old' },
+        after: { id: '1', title: 'new' },
+      })
+    })
+
+    it('pairs before/after entities by id for multi-row mutations', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = afterArgs({
+        loadAfterMutationEntities: vi.fn().mockResolvedValue([
+          { id: 'b', n: 21 },
+          { id: 'a', n: 11 },
+        ]),
+        beforeMutationEntities: [
+          { id: 'a', n: 10 },
+          { id: 'b', n: 20 },
+        ],
+      })
+
+      await plugin.onEntityMutation.afterEntityMutation!(args)
+
+      expect(registry.emit).toHaveBeenCalledTimes(2)
+      expect(registry.emit).toHaveBeenCalledWith('entity.Post.updated', {
+        model: 'Post',
+        action: 'updated',
+        before: { id: 'b', n: 20 },
+        after: { id: 'b', n: 21 },
+      })
+      expect(registry.emit).toHaveBeenCalledWith('entity.Post.updated', {
+        model: 'Post',
+        action: 'updated',
+        before: { id: 'a', n: 10 },
+        after: { id: 'a', n: 11 },
+      })
+    })
+
+    it('emits entity.{Model}.created with after only', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const args = afterArgs({
+        action: 'create',
+        beforeMutationEntities: undefined,
+        loadAfterMutationEntities: vi.fn().mockResolvedValue([{ id: '9', title: 'fresh' }]),
+      })
+
+      await plugin.onEntityMutation.afterEntityMutation!(args)
+
+      expect(registry.emit).toHaveBeenCalledExactlyOnceWith('entity.Post.created', {
+        model: 'Post',
+        action: 'created',
+        before: undefined,
+        after: { id: '9', title: 'fresh' },
+      })
+    })
+
+    it('emits entity.{Model}.deleted with before only and does not load after-entities', async () => {
+      registry.hasListeners.mockReturnValue(true)
+      const loadAfter = vi.fn()
+      const args = afterArgs({
+        action: 'delete',
+        loadAfterMutationEntities: loadAfter,
+        beforeMutationEntities: [{ id: '1', title: 'gone' }],
+      })
+
+      await plugin.onEntityMutation.afterEntityMutation!(args)
+
+      expect(loadAfter).not.toHaveBeenCalled()
+      expect(registry.emit).toHaveBeenCalledExactlyOnceWith('entity.Post.deleted', {
+        model: 'Post',
+        action: 'deleted',
+        before: { id: '1', title: 'gone' },
+        after: undefined,
+      })
+    })
+
+    it('emits nothing when no listener exists', async () => {
+      registry.hasListeners.mockReturnValue(false)
+      const args = afterArgs()
+
+      await plugin.onEntityMutation.afterEntityMutation!(args)
+
+      expect(registry.emit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/framework/src/database/plugins/event-emitter.plugin.ts
+++ b/packages/framework/src/database/plugins/event-emitter.plugin.ts
@@ -1,9 +1,42 @@
-import { type RuntimePlugin } from '@zenstackhq/orm'
-import { type SchemaDef } from '@zenstackhq/orm/schema'
-import type { EventName, IEventRegistry } from 'stratal/events'
+import { type EntityMutationHooksDef, type RuntimePlugin } from '@zenstackhq/orm';
+import { type SchemaDef } from '@zenstackhq/orm/schema';
+import type { EventContext, EventName, IEventRegistry } from 'stratal/events';
+import type { ModelName } from '../event-types';
 
 export interface EventEmitterPluginOptions {
   eventRegistry: IEventRegistry
+}
+
+type EntityMutationAction = 'create' | 'update' | 'delete'
+
+const ENTITY_ACTION_VERB = {
+  create: 'created',
+  update: 'updated',
+  delete: 'deleted',
+} as const satisfies Record<EntityMutationAction, string>
+
+type Entity = Record<string, unknown>
+
+/**
+ * Pair before/after entity snapshots for a mutation. Rows are matched by
+ * `id` when both sides carry one, falling back to positional pairing.
+ */
+function pairEntities(
+  before: Entity[] | undefined,
+  after: Entity[] | undefined
+): { before: Entity | undefined; after: Entity | undefined }[] {
+  const primary = after ?? before ?? []
+  const counterpart = after ? before : undefined
+
+  return primary.map((entity, index) => {
+    const match = counterpart
+      ? counterpart.find((c) => c.id !== undefined && c.id === entity.id) ?? counterpart[index]
+      : undefined
+
+    return after
+      ? { before: match, after: entity }
+      : { before: entity, after: undefined }
+  })
 }
 
 /**
@@ -12,6 +45,17 @@ export interface EventEmitterPluginOptions {
  * Emits events in the format:
  * - `before.{Model}.{operation}` - Before the database operation
  * - `after.{Model}.{operation}` - After the database operation
+ *
+ * Additionally emits entity-mutation events carrying full entity snapshots:
+ * - `entity.{Model}.created` - `{ after }`
+ * - `entity.{Model}.updated` - `{ before, after }`
+ * - `entity.{Model}.deleted` - `{ before }`
+ *
+ * Entity events are listener-driven: the pre-mutation snapshot is only
+ * loaded (inside the mutation's transaction) when `hasListeners()` reports
+ * a matching subscription, so models nobody observes pay no cost. Note that
+ * a wildcard subscription (`entity`) therefore makes every model pay the
+ * pre-read — subscribe per model when cost matters.
  *
  * @example
  * ```typescript
@@ -29,6 +73,51 @@ export class EventEmitterPlugin implements RuntimePlugin<SchemaDef, Record<strin
   readonly id = 'event-emitter'
 
   constructor(private options: EventEmitterPluginOptions) { }
+
+  onEntityMutation: EntityMutationHooksDef<SchemaDef> = {
+    // Run after-hooks inside the mutation's transaction boundary so they
+    // execute within the caller's async context (AsyncLocalStorage intact):
+    // listeners resolve from the live request scope and tenant schema
+    // switching still applies. Post-commit hooks would run detached from the
+    // request's ALS. Listeners registered `blocking: false` still do their
+    // real work outside the transaction via waitUntil.
+    runAfterMutationWithinTransaction: true,
+
+    beforeEntityMutation: async (args) => {
+      // Created rows have no prior state to snapshot
+      if (args.action === 'create') return
+
+      const event = `entity.${args.model}.${ENTITY_ACTION_VERB[args.action]}` as EventName
+      if (!this.options.eventRegistry.hasListeners(event)) return
+
+      // Runs inside the mutation's transaction; ZenStack hands the result
+      // to afterEntityMutation as `beforeMutationEntities`
+      await args.loadBeforeMutationEntities()
+    },
+
+    afterEntityMutation: async (args) => {
+      const { model, action, beforeMutationEntities } = args
+      const verb = ENTITY_ACTION_VERB[action]
+      const event = `entity.${model}.${verb}` as EventName
+      const { eventRegistry } = this.options
+
+      if (!eventRegistry.hasListeners(event)) return
+
+      const after = action === 'delete' ? undefined : await args.loadAfterMutationEntities()
+
+      for (const pair of pairEntities(beforeMutationEntities, after)) {
+        // Producer boundary: ZenStack types `model` as plain string, but at
+        // runtime it is always a schema model name — assert that one fact.
+        const context: EventContext<'entity'> = {
+          model: model as ModelName,
+          action: verb,
+          before: pair.before,
+          after: pair.after,
+        }
+        await eventRegistry.emit(event, context)
+      }
+    },
+  }
 
   onQuery = async ({ model, operation, args, proceed }: {
     model: string

--- a/packages/framework/src/database/plugins/event-emitter.plugin.ts
+++ b/packages/framework/src/database/plugins/event-emitter.plugin.ts
@@ -27,10 +27,13 @@ function pairEntities(
 ): { before: Entity | undefined; after: Entity | undefined }[] {
   const primary = after ?? before ?? []
   const counterpart = after ? before : undefined
+  const counterpartById = counterpart
+    ? new Map(counterpart.filter((c) => c.id !== undefined).map((c) => [c.id, c]))
+    : undefined
 
   return primary.map((entity, index) => {
     const match = counterpart
-      ? counterpart.find((c) => c.id !== undefined && c.id === entity.id) ?? counterpart[index]
+      ? (entity.id !== undefined ? counterpartById?.get(entity.id) : undefined) ?? counterpart[index]
       : undefined
 
     return after

--- a/packages/framework/test/e2e/events.spec.ts
+++ b/packages/framework/test/e2e/events.spec.ts
@@ -150,6 +150,117 @@ describe('Event System', () => {
     })
   })
 
+  describe('Entity Mutation Events', () => {
+    interface EntityEvent {
+      model: string
+      action: string
+      before?: Record<string, unknown>
+      after?: Record<string, unknown>
+    }
+
+    it('emits entity.Post.created with the after snapshot', async () => {
+      await module.runInRequestScope(async () => {
+        const db = module.getDb()
+        const eventRegistry = module.get<EventRegistry>(DI_TOKENS.EventRegistry)
+        const received: EntityEvent[] = []
+        const handler = (ctx: unknown): void => { received.push(ctx as EntityEvent) }
+
+        eventRegistry.on('entity.Post.created', handler, { blocking: true })
+        try {
+          await db.post.create({
+            data: { title: 'Fresh Post', content: 'Body', authorId: REGULAR_USER_ID },
+          })
+        } finally {
+          eventRegistry.off('entity.Post.created', handler)
+        }
+
+        expect(received).toHaveLength(1)
+        expect(received[0].action).toBe('created')
+        expect(received[0].before).toBeUndefined()
+        expect(received[0].after?.title).toBe('Fresh Post')
+      })
+    })
+
+    it('emits entity.Post.updated with before and after snapshots', async () => {
+      await module.runInRequestScope(async () => {
+        const db = module.getDb()
+        const eventRegistry = module.get<EventRegistry>(DI_TOKENS.EventRegistry)
+        const received: EntityEvent[] = []
+        const handler = (ctx: unknown): void => { received.push(ctx as EntityEvent) }
+
+        const post = await db.post.create({
+          data: { title: 'Original Title', content: 'Body', authorId: REGULAR_USER_ID },
+        })
+
+        eventRegistry.on('entity.Post.updated', handler, { blocking: true })
+        try {
+          await db.post.update({ where: { id: post.id }, data: { title: 'Changed Title' } })
+        } finally {
+          eventRegistry.off('entity.Post.updated', handler)
+        }
+
+        expect(received).toHaveLength(1)
+        expect(received[0].model).toBe('Post')
+        expect(received[0].action).toBe('updated')
+        expect(received[0].before?.title).toBe('Original Title')
+        expect(received[0].after?.title).toBe('Changed Title')
+      })
+    })
+
+    it('emits entity.Post.deleted with the before snapshot', async () => {
+      await module.runInRequestScope(async () => {
+        const db = module.getDb()
+        const eventRegistry = module.get<EventRegistry>(DI_TOKENS.EventRegistry)
+        const received: EntityEvent[] = []
+        const handler = (ctx: unknown): void => { received.push(ctx as EntityEvent) }
+
+        const post = await db.post.create({
+          data: { title: 'Doomed Post', content: 'Body', authorId: REGULAR_USER_ID },
+        })
+
+        eventRegistry.on('entity.Post.deleted', handler, { blocking: true })
+        try {
+          await db.post.delete({ where: { id: post.id } })
+        } finally {
+          eventRegistry.off('entity.Post.deleted', handler)
+        }
+
+        expect(received).toHaveLength(1)
+        expect(received[0].action).toBe('deleted')
+        expect(received[0].before?.title).toBe('Doomed Post')
+        expect(received[0].after).toBeUndefined()
+      })
+    })
+
+    it('emits one entity event per row for multi-row mutations', async () => {
+      await module.runInRequestScope(async () => {
+        const db = module.getDb()
+        const eventRegistry = module.get<EventRegistry>(DI_TOKENS.EventRegistry)
+        const received: EntityEvent[] = []
+        const handler = (ctx: unknown): void => { received.push(ctx as EntityEvent) }
+
+        await db.post.create({ data: { title: 'Bulk A', authorId: REGULAR_USER_ID } })
+        await db.post.create({ data: { title: 'Bulk B', authorId: REGULAR_USER_ID } })
+
+        eventRegistry.on('entity.Post.updated', handler, { blocking: true })
+        try {
+          await db.post.updateMany({
+            where: { title: { startsWith: 'Bulk' } },
+            data: { published: true },
+          })
+        } finally {
+          eventRegistry.off('entity.Post.updated', handler)
+        }
+
+        expect(received).toHaveLength(2)
+        const byTitle = new Map(received.map((e) => [e.before?.title, e]))
+        expect(byTitle.get('Bulk A')?.before?.published).toBe(false)
+        expect(byTitle.get('Bulk A')?.after?.published).toBe(true)
+        expect(byTitle.get('Bulk B')?.after?.published).toBe(true)
+      })
+    })
+  })
+
   describe('Error Isolation', () => {
     it('throwing handler does not crash other handlers', async () => {
       await module.runInRequestScope(async () => {

--- a/packages/inertia/src/commands/inertia-dev.command.ts
+++ b/packages/inertia/src/commands/inertia-dev.command.ts
@@ -13,12 +13,16 @@ export class InertiaDevCommand extends Command {
     const host = this.boolean('host')
     const persistTo = this.string('persist-to')
     const inspectorPortRaw = this.string('inspector-port')
-    const inspectorPort =
-      inspectorPortRaw === undefined
-        ? undefined
-        : inspectorPortRaw === 'false'
-          ? (false as const)
-          : Number(inspectorPortRaw)
+    let inspectorPort: number | false | undefined
+    if (inspectorPortRaw === 'false') {
+      inspectorPort = false
+    } else if (inspectorPortRaw !== undefined) {
+      inspectorPort = Number(inspectorPortRaw)
+      if (!Number.isInteger(inspectorPort) || inspectorPort < 0 || inspectorPort > 65535) {
+        this.fail(`Invalid --inspector-port "${inspectorPortRaw}". Expected an integer between 0 and 65535, or "false" to disable.`)
+        return 1
+      }
+    }
     const cwd = process.cwd()
 
     const entryPath = 'src/inertia/app.tsx'

--- a/packages/inertia/src/commands/inertia-dev.command.ts
+++ b/packages/inertia/src/commands/inertia-dev.command.ts
@@ -5,13 +5,20 @@ import { Command } from 'stratal/quarry'
 import { writeTempViteConfig } from '../vite/create-vite-config'
 
 export class InertiaDevCommand extends Command {
-  static command = 'inertia:dev {--port= : Dev server port} {--host : Expose to network} {--persist-to= : Shared persist directory for @cloudflare/vite-plugin (relative to cwd; the plugin appends /v3). Use to share R2/KV/cache emulator state across multiple workers in dev.}'
+  static command = 'inertia:dev {--port= : Dev server port} {--host : Expose to network} {--inspector-port= : Worker debugger inspector port (number, or "false" to disable). Set a distinct value per worker to avoid EADDRINUSE when running multiple Inertia workers concurrently.} {--persist-to= : Shared persist directory for @cloudflare/vite-plugin (relative to cwd; the plugin appends /v3). Use to share R2/KV/cache emulator state across multiple workers in dev.}'
   static description = 'Start Inertia.js Vite development server'
 
   async handle(): Promise<number | undefined> {
     const port = this.number('port')
     const host = this.boolean('host')
     const persistTo = this.string('persist-to')
+    const inspectorPortRaw = this.string('inspector-port')
+    const inspectorPort =
+      inspectorPortRaw === undefined
+        ? undefined
+        : inspectorPortRaw === 'false'
+          ? (false as const)
+          : Number(inspectorPortRaw)
     const cwd = process.cwd()
 
     const entryPath = 'src/inertia/app.tsx'
@@ -24,6 +31,7 @@ export class InertiaDevCommand extends Command {
       cwd,
       server: { port, host },
       persistTo,
+      inspectorPort,
     })
 
     this.info('Starting Vite dev server...')

--- a/packages/inertia/src/vite/create-vite-config.ts
+++ b/packages/inertia/src/vite/create-vite-config.ts
@@ -6,6 +6,14 @@ export interface TempViteConfigOptions {
   outDir?: string
   persistTo?: string
   /**
+   * Worker debugger inspector port passed to `@cloudflare/vite-plugin`.
+   * Pass a distinct number per worker to avoid the `EADDRINUSE` race that
+   * happens when several Inertia workers boot concurrently and all probe the
+   * default port (9229). Pass `false` to disable the inspector entirely.
+   * Left `undefined` preserves the plugin's default auto-pick behaviour.
+   */
+  inspectorPort?: number | false
+  /**
    * Path (relative to `cwd`) to the Vite client manifest the worker bundle
    * should inline. Defaults to `dist/client/.vite/manifest.json`, matching
    * what `quarry inertia:build` emits in phase 1.
@@ -28,9 +36,14 @@ export function writeTempViteConfig(options: TempViteConfigOptions): string {
     ? `outDir: '${options.outDir}',`
     : ''
 
-  const cloudflareArgs = options.persistTo
-    ? `{ persistState: { path: ${JSON.stringify(options.persistTo)} } }`
-    : ''
+  const cloudflareOptions: string[] = []
+  if (options.persistTo) {
+    cloudflareOptions.push(`persistState: { path: ${JSON.stringify(options.persistTo)} }`)
+  }
+  if (options.inspectorPort !== undefined) {
+    cloudflareOptions.push(`inspectorPort: ${options.inspectorPort === false ? 'false' : options.inspectorPort}`)
+  }
+  const cloudflareArgs = cloudflareOptions.length ? `{ ${cloudflareOptions.join(', ')} }` : ''
 
   const stratalArgs = options.clientManifestPath
     ? `{ clientManifestPath: ${JSON.stringify(options.clientManifestPath)} }`

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -75,6 +75,7 @@
     "msw": "^2.14.6"
   },
   "peerDependencies": {
+    "@better-auth/core": ">=1.6",
     "@stratal/framework": ">=0.0.24",
     "better-auth": ">=1.4",
     "pg": "^8.0.0",
@@ -82,6 +83,9 @@
     "vitest": "^4.1.0"
   },
   "peerDependenciesMeta": {
+    "@better-auth/core": {
+      "optional": true
+    },
     "@stratal/framework": {
       "optional": true
     },
@@ -93,6 +97,7 @@
     }
   },
   "devDependencies": {
+    "@better-auth/core": "^1.6.11",
     "@cloudflare/workers-types": "4.20260603.1",
     "@stratal/framework": "workspace:*",
     "@types/node": "^25.9.1",

--- a/packages/testing/src/auth/acting-as.ts
+++ b/packages/testing/src/auth/acting-as.ts
@@ -1,3 +1,4 @@
+import { runWithEndpointContext, type AuthEndpointContext } from '@better-auth/core/context'
 import type { AuthService } from '@stratal/framework/auth'
 import { type GenericEndpointContext } from 'better-auth'
 import { setSessionCookie } from 'better-auth/cookies'
@@ -43,10 +44,20 @@ export class ActingAs {
 
     const secret = ctx.secret
 
-    const session = await ctx.internalAdapter.createSession(
-      user.id,
-      undefined,
-      { ipAddress: '127.0.0.1', userAgent: 'test-client' }
+    // Mirror production: session writes always happen inside a Better Auth
+    // endpoint, so database hooks receive the endpoint context (e.g. for
+    // internalAdapter lookups). The cast bridges better-auth's own generic
+    // variance — `$context` is typed with the instance's concrete plugin
+    // registry while AuthEndpointContext expects the default generics (same
+    // impedance as the GenericEndpointContext cast below).
+    const session = await runWithEndpointContext(
+      { context: ctx } as unknown as AuthEndpointContext,
+      () =>
+        ctx.internalAdapter.createSession(
+          user.id,
+          undefined,
+          { ipAddress: '127.0.0.1', userAgent: 'test-client' }
+        )
     )
 
     const dbUser = await ctx.internalAdapter.findUserById(user.id)

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,7 +329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@better-auth/core@npm:1.6.14, @better-auth/core@npm:^1.6.14":
+"@better-auth/core@npm:1.6.14, @better-auth/core@npm:^1.6.11, @better-auth/core@npm:^1.6.14":
   version: 1.6.14
   resolution: "@better-auth/core@npm:1.6.14"
   dependencies:
@@ -2830,6 +2830,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@stratal/testing@workspace:packages/testing"
   dependencies:
+    "@better-auth/core": "npm:^1.6.11"
     "@cloudflare/vitest-pool-workers": "npm:^0.16.12"
     "@cloudflare/workers-types": "npm:4.20260603.1"
     "@golevelup/ts-vitest": "npm:^4.0.0"
@@ -2846,12 +2847,15 @@ __metadata:
     typescript: "npm:^6.0.3"
     vitest: "npm:~4.1.8"
   peerDependencies:
+    "@better-auth/core": ">=1.6"
     "@stratal/framework": ">=0.0.24"
     better-auth: ">=1.4"
     pg: ^8.0.0
     stratal: ">=0.0.24"
     vitest: ^4.1.0
   peerDependenciesMeta:
+    "@better-auth/core":
+      optional: true
     "@stratal/framework":
       optional: true
     better-auth:


### PR DESCRIPTION
## Summary

Adds typed `entity.{Model}.{created|updated|deleted}` events carrying full entity snapshots (vs. raw query args in `before.*`/`after.*`), powered by a new `EventRegistry.hasListeners()` so unobserved models pay zero snapshot cost. Also hardens DI `tryResolve` for request-scoped providers outside a request, adds `--inspector-port` to `inertia:dev`, and fixes `actingAs` session creation for Better Auth â¥1.6.

### Changes

- **core/events**: `hasListeners()` on `EventRegistry`/`IEventRegistry` using the same wildcard matching as `emit()`
- **framework/database**: `EventEmitterPlugin` implements ZenStack `onEntityMutation` hooks â pre-mutation snapshot loaded inside the transaction only when a listener matches; before/after rows paired by `id`; one event per row; new `EntityEvents` types with wildcard subscriptions (`entity.{Model}`, `entity.{verb}`, `entity`)
- **core/di**: `tryResolve()` returns `undefined` (instead of throwing) for request-scoped providers outside a request scope, following aliases and decorator metadata; `ContainerLike` gains `tryResolve`; non-HTTP scopes get a `header: () => undefined` stub
- **inertia**: `--inspector-port` on `inertia:dev` (number or `false`) to avoid `EADDRINUSE` when running multiple workers
- **testing**: `actingAs` wraps `createSession` in `runWithEndpointContext` so database hooks see the endpoint context; adds optional `@better-auth/core` peer dep

## How to Test

- `yarn workspace stratal test` â new `event-registry.spec.ts` and container `tryResolve` specs
- `yarn workspace @stratal/framework test` â new `event-emitter.plugin.spec.ts` unit tests
- `yarn workspace @stratal/framework test:e2e` â entity mutation e2e specs (needs Docker Postgres)
- Run two `inertia:dev` workers with distinct `--inspector-port` values â no `EADDRINUSE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hasListeners()` method to event registry to optimize event emission checks.
  * Introduced type-safe entity mutation events (`entity.Model.created/updated/deleted`) with before/after snapshots.
  * Added `--inspector-port` CLI option to Inertia dev command.
  * Added `tryResolve()` for optional dependency resolution.

* **Improvements**
  * Enhanced request-scoped dependency handling in dependency injection.
  * Improved event emission for entity mutations.
  * Enhanced authentication testing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->