### PR TITLE
feat(core,inertia): trailing-slash exclusions via `{ mode, exclude }` config

### DIFF
--- a/.agents/skills/stratal/SKILL.md
+++ b/.agents/skills/stratal/SKILL.md
@@ -89,7 +89,7 @@ Constructor config:
 - `exceptionHandler?` — Custom `ExceptionHandler` subclass
 - `logging?` — `{ level?, formatter? }` (`'json'` | `'pretty'`)
 - `versioning?` — `{ prefix?, defaultVersion? }`
-- `trailingSlash?` — `'ignore'` (default) | `'always'` | `'never'`. Redirects non-canonical forms with 308 and applies the same canonicalisation to all URL helpers. See `references/routing.md`.
+- `trailingSlash?` — `'ignore'` (default) | `'always'` | `'never'`, or `{ mode, exclude }` to exempt paths (string segment-prefixes or RegExps) whose canonical form is external (e.g. OAuth callbacks). Redirects non-canonical forms with 308 and applies the same canonicalisation to all URL helpers. See `references/routing.md`.
 
 ### CLI Entry (`src/quarry.ts`)
 

--- a/.agents/skills/stratal/references/routing.md
+++ b/.agents/skills/stratal/references/routing.md
@@ -556,11 +556,44 @@ The configured mode is also applied to URL-generation helpers so generated links
 - `ctx.route(name, params?, options?)` (RouterContext)
 - `Uri.route()`, `Uri.to()`, `Uri.query()`, `Uri.current()`, `Uri.full()`
 
-Type export:
+### Exclusions
+
+For routes whose canonical form is dictated by an external party (e.g. an OAuth
+redirect URI registered with an IdP and matched byte-for-byte), pass
+`{ mode, exclude }` instead of a bare mode:
 
 ```typescript
-import type { TrailingSlashMode } from 'stratal/router'
-// 'ignore' | 'always' | 'never'
+export default new Stratal({
+  module: AppModule,
+  trailingSlash: {
+    mode: 'always',
+    exclude: ['/auth/oauth2', /^\/webhooks\//],
+  },
+})
+```
+
+Excluded paths are never redirected and never rewritten by URL generation —
+both slash forms are served as requested.
+
+- `string` patterns are segment-aware prefixes: `'/auth/oauth2'` exempts
+  `/auth/oauth2` and `/auth/oauth2/callback/x`, but not `/auth/oauth2-other`.
+- `RegExp` patterns are tested against both forms of the pathname (with and
+  without the trailing slash), so anchoring to either form exempts both.
+- Patterns match in **route space**: with path-based locale detection, a
+  leading locale segment is stripped before matching — `'/callback'` also
+  exempts `/fr/callback`.
+- Exclusions are server-side only. The Inertia adapter shares just the
+  resolved mode with the client; client-canonicalised URLs for excluded paths
+  never redirect because the server serves both forms.
+
+Type exports:
+
+```typescript
+import type { TrailingSlashConfig, TrailingSlashExclude, TrailingSlashMode, TrailingSlashOptions } from 'stratal/router'
+// TrailingSlashMode    — 'ignore' | 'always' | 'never'
+// TrailingSlashExclude — string | RegExp
+// TrailingSlashOptions — { mode: TrailingSlashMode; exclude?: readonly TrailingSlashExclude[] }
+// TrailingSlashConfig  — TrailingSlashMode | TrailingSlashOptions
 ```
 
 ## Response Validation

--- a/.changeset/trailing-slash-exclusions.md
+++ b/.changeset/trailing-slash-exclusions.md
@@ -1,0 +1,14 @@
+---
+"stratal": minor
+"@stratal/inertia": minor
+---
+
+Trailing-slash exclusions: `trailingSlash` accepts `{ mode, exclude }`
+
+### Details
+
+- `trailingSlash` application config now accepts `{ mode, exclude }` alongside a bare mode. Excluded paths are never redirected (308) and never rewritten by URL generation — for routes whose canonical form is owned externally (e.g. OAuth redirect URIs matched byte-for-byte).
+- String patterns are segment-aware prefixes; RegExp patterns match both slash forms of the pathname regardless of anchoring.
+- Exclusions match in route space: with path-based locale detection, a leading locale segment is stripped before matching, so `'/callback'` also exempts `/fr/callback` — in the redirect middleware, `Uri` helpers, and hreflang link generation.
+- `@stratal/inertia` threads the widened config through hreflang URL generation and shares only the resolved mode with the React client (exclusions are server-side; excluded paths are served in both slash forms, so client-built URLs never redirect).
+- New exports from `stratal/router`: `resolveTrailingSlash`, `isTrailingSlashExcluded`, and the `TrailingSlashConfig` / `TrailingSlashOptions` / `TrailingSlashExclude` types.

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -23,7 +23,7 @@ import type { QueueManager } from './queue/queue-manager'
 import type { RouterContext } from './router'
 import type { HonoApp } from './router/hono-app'
 import { ROUTER_TOKENS } from './router/router.tokens'
-import type { TrailingSlashMode, VersioningOptions } from './router/types'
+import type { TrailingSlashConfig, VersioningOptions } from './router/types'
 import type { Seeder } from './seeder/seeder'
 import { SEEDER_TOKENS } from './seeder/seeder-registry'
 import type { SeederRegistry } from './seeder/seeder-registry'
@@ -36,7 +36,7 @@ export interface ApplicationConfig {
     formatter?: 'json' | 'pretty'
   }
   versioning?: VersioningOptions
-  trailingSlash?: TrailingSlashMode
+  trailingSlash?: TrailingSlashConfig
   exceptionHandler?: Constructor<ExceptionHandler>
 }
 

--- a/packages/core/src/router/__tests__/trailing-slash.spec.ts
+++ b/packages/core/src/router/__tests__/trailing-slash.spec.ts
@@ -1,3 +1,4 @@
+import type { MiddlewareHandler } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Application, type ApplicationOptions } from '../../application'
 import type { StratalEnv } from '../../env'
@@ -6,6 +7,7 @@ import { LogLevel } from '../../logger'
 import { Module } from '../../module/module.decorator'
 import { Controller } from '../decorators/controller.decorator'
 import { Route } from '../decorators/route.decorator'
+import { createTrailingSlashRedirect } from '../middleware/trailing-slash-redirect'
 import type { RouterContext } from '../router-context'
 
 const handlerHits = { index: 0, create: 0 }
@@ -224,6 +226,48 @@ describe('trailing-slash handling', () => {
     it('does not redirect the root path', async () => {
       const res = await fetchPath(app, '/')
       expect(res.status).not.toBe(308)
+    })
+  })
+
+  describe('createTrailingSlashRedirect with locales (path-based i18n)', () => {
+    async function invoke(mw: MiddlewareHandler, path: string) {
+      let redirected: string | null = null
+      let nexted = false
+      const c = {
+        req: { url: `http://localhost${path}` },
+        redirect: (location: string, status: number) => {
+          redirected = location
+          return new Response(null, { status })
+        },
+      }
+      await mw(c as never, () => {
+        nexted = true
+        return Promise.resolve()
+      })
+      return { redirected, nexted }
+    }
+
+    it('exempts locale-prefixed forms of excluded paths', async () => {
+      const mw = createTrailingSlashRedirect(
+        { mode: 'always', exclude: ['/callback'] },
+        () => ['en', 'fr'],
+      )!
+
+      expect(await invoke(mw, '/fr/callback')).toEqual({ redirected: null, nexted: true })
+      expect(await invoke(mw, '/callback')).toEqual({ redirected: null, nexted: true })
+      expect((await invoke(mw, '/fr/users')).redirected).toBe('/fr/users/')
+    })
+
+    it('locale list is read lazily per request', async () => {
+      let locales: string[] | undefined
+      const mw = createTrailingSlashRedirect({ mode: 'always', exclude: ['/callback'] }, () => locales)!
+
+      // Before i18n resolves its locales, the prefixed form is not exempt…
+      expect((await invoke(mw, '/fr/callback')).redirected).toBe('/fr/callback/')
+
+      // …after it resolves, it is.
+      locales = ['en', 'fr']
+      expect(await invoke(mw, '/fr/callback')).toEqual({ redirected: null, nexted: true })
     })
   })
 })

--- a/packages/core/src/router/__tests__/trailing-slash.spec.ts
+++ b/packages/core/src/router/__tests__/trailing-slash.spec.ts
@@ -28,7 +28,15 @@ class UsersController {
   }
 }
 
-@Module({ controllers: [UsersController] })
+@Controller('/callback')
+class CallbackController {
+  @Route({ response: z.object({ ok: z.boolean() }) })
+  index(ctx: RouterContext) {
+    return ctx.json({ ok: true })
+  }
+}
+
+@Module({ controllers: [UsersController, CallbackController] })
 class TrailingSlashModule { }
 
 const mockEnv = { ENVIRONMENT: 'test' } as StratalEnv
@@ -150,6 +158,35 @@ describe('trailing-slash handling', () => {
     it('does not redirect the root path', async () => {
       const res = await fetchPath(app, '/')
       expect(res.status).not.toBe(308)
+    })
+  })
+
+  describe("mode 'always' with exclusions", () => {
+    let app: Application
+
+    beforeEach(async () => {
+      app = createApp({ trailingSlash: { mode: 'always', exclude: ['/callback'] } })
+      await app.initialize()
+    })
+
+    afterEach(async () => {
+      await app.shutdown()
+    })
+
+    it('serves the excluded path without redirecting (non-trailing form)', async () => {
+      const res = await fetchPath(app, '/callback')
+      expect(res.status).toBe(200)
+    })
+
+    it('serves the excluded path without redirecting (trailing form)', async () => {
+      const res = await fetchPath(app, '/callback/')
+      expect(res.status).toBe(200)
+    })
+
+    it('still redirects non-excluded paths', async () => {
+      const res = await fetchPath(app, '/users')
+      expect(res.status).toBe(308)
+      expect(res.headers.get('Location')).toBe('/users/')
     })
   })
 

--- a/packages/core/src/router/__tests__/uri.spec.ts
+++ b/packages/core/src/router/__tests__/uri.spec.ts
@@ -4,10 +4,10 @@ import { RouterError } from '../router.error'
 import type { RegisteredRoute, RouteRegistry } from '../route-registry'
 import type { RouterContext } from '../router-context'
 import type { LocalePathService } from '../services/locale-path.service'
-import type { LocalePathConfig, TrailingSlashMode } from '../types'
+import type { LocalePathConfig, TrailingSlashConfig } from '../types'
 import { Uri, buildRouteUrl } from '../uri'
 
-const createMockApplication = (trailingSlash?: TrailingSlashMode) => ({
+const createMockApplication = (trailingSlash?: TrailingSlashConfig) => ({
   config: { trailingSlash },
 }) as unknown as Application
 
@@ -213,7 +213,7 @@ describe('Uri', () => {
   const setupUri = (
     routes: Record<string, RegisteredRoute> = {},
     contextOverrides: Parameters<typeof createMockRouterContext>[0] = {},
-    trailingSlash?: TrailingSlashMode,
+    trailingSlash?: TrailingSlashConfig,
     localePathOverrides: Parameters<typeof createMockLocalePathService>[0] = {},
   ) => {
     mockRegistry = createMockRegistry(routes)
@@ -566,6 +566,43 @@ describe('Uri', () => {
           }),
         }, {}, 'always')
         expect(uri.route('tenant.dashboard', { tenant: 'acme' })).toBe('https://acme.myapp.com/dashboard/')
+      })
+    })
+
+    describe('exclusions ({ mode, exclude })', () => {
+      it('route() leaves excluded paths as authored (string pattern, segment-aware)', () => {
+        setupUri(
+          { 'oauth.callback': createRoute({ path: '/auth/oauth2/callback/:id', paramNames: ['id'] }) },
+          {},
+          { mode: 'always', exclude: ['/auth/oauth2'] },
+        )
+        expect(uri.route('oauth.callback', { id: 'p1' })).toBe('/auth/oauth2/callback/p1')
+      })
+
+      it('still canonicalises non-excluded paths', () => {
+        setupUri(
+          { 'users.index': createRoute() },
+          {},
+          { mode: 'always', exclude: ['/auth/oauth2'] },
+        )
+        expect(uri.route('users.index')).toBe('/users/')
+      })
+
+      it('does not treat string patterns as loose prefixes', () => {
+        setupUri({}, {}, { mode: 'always', exclude: ['/auth/oauth2'] })
+        expect(uri.to('/auth/oauth2-other')).toBe('/auth/oauth2-other/')
+      })
+
+      it('supports RegExp patterns', () => {
+        setupUri({}, {}, { mode: 'always', exclude: [/^\/webhooks\//] })
+        expect(uri.to('/webhooks/github')).toBe('/webhooks/github')
+        expect(uri.to('/users')).toBe('/users/')
+      })
+
+      it("applies to 'never' mode too", () => {
+        setupUri({}, {}, { mode: 'never', exclude: ['/auth/oauth2'] })
+        expect(uri.to('/auth/oauth2/callback/p1/')).toBe('/auth/oauth2/callback/p1/')
+        expect(uri.to('/users/')).toBe('/users')
       })
     })
 

--- a/packages/core/src/router/__tests__/uri.spec.ts
+++ b/packages/core/src/router/__tests__/uri.spec.ts
@@ -599,6 +599,28 @@ describe('Uri', () => {
         expect(uri.to('/users')).toBe('/users/')
       })
 
+      it('RegExp patterns exempt both slash forms regardless of anchoring', () => {
+        // Pattern anchored to the bare form still exempts the trailing form.
+        setupUri({}, {}, { mode: 'never', exclude: [/^\/webhooks$/] })
+        expect(uri.to('/webhooks/')).toBe('/webhooks/')
+
+        // Pattern anchored to the trailing form still exempts the bare form.
+        setupUri({}, {}, { mode: 'always', exclude: [/^\/webhooks\/$/] })
+        expect(uri.to('/webhooks')).toBe('/webhooks')
+      })
+
+      it('matches exclusions against the locale-stripped path', () => {
+        setupUri(
+          {},
+          {},
+          { mode: 'always', exclude: ['/callback'] },
+          { localePathConfig: { allLocales: ['en', 'fr'], prefixedLocales: ['fr'], defaultLocale: 'en' } },
+        )
+        expect(uri.to('/fr/callback')).toBe('/fr/callback')
+        expect(uri.to('/callback')).toBe('/callback')
+        expect(uri.to('/fr/users')).toBe('/fr/users/')
+      })
+
       it("applies to 'never' mode too", () => {
         setupUri({}, {}, { mode: 'never', exclude: ['/auth/oauth2'] })
         expect(uri.to('/auth/oauth2/callback/p1/')).toBe('/auth/oauth2/callback/p1/')

--- a/packages/core/src/router/hono-app.ts
+++ b/packages/core/src/router/hono-app.ts
@@ -17,6 +17,8 @@ import { RouterError } from './router.error'
 import { createLoggerMiddleware, createMiddlewareChain, createTrailingSlashRedirect } from './middleware'
 import type { Middleware } from './middleware.interface'
 import { RouterContext } from './router-context'
+import { ROUTER_TOKENS } from './router.tokens'
+import type { LocalePathService } from './services/locale-path.service'
 import { RouteRegistrationService } from './services/route-registration.service'
 import type { RouterEnv, TrailingSlashConfig } from './types'
 
@@ -88,8 +90,10 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
     }) as typeof this.use
 
     // Trailing-slash redirect runs first so redirected requests skip request-scope
-    // and logger overhead.
-    const trailingSlashRedirect = createTrailingSlashRedirect(trailingSlash)
+    // and logger overhead. Locales are read lazily — the i18n module (and thus
+    // LocalePathService) initialises after HonoApp is constructed.
+    const trailingSlashRedirect = createTrailingSlashRedirect(trailingSlash, () =>
+      this._container.tryResolve<LocalePathService>(ROUTER_TOKENS.LocalePathService)?.localePathConfig?.allLocales)
     if (trailingSlashRedirect) {
       this.nativeUse('*', trailingSlashRedirect)
     }

--- a/packages/core/src/router/hono-app.ts
+++ b/packages/core/src/router/hono-app.ts
@@ -18,7 +18,7 @@ import { createLoggerMiddleware, createMiddlewareChain, createTrailingSlashRedir
 import type { Middleware } from './middleware.interface'
 import { RouterContext } from './router-context'
 import { RouteRegistrationService } from './services/route-registration.service'
-import type { RouterEnv, TrailingSlashMode } from './types'
+import type { RouterEnv, TrailingSlashConfig } from './types'
 
 const isMiddlewareClass = (arg: unknown): arg is Constructor<Middleware> =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -52,7 +52,7 @@ export class HonoApp extends OpenAPIHono<RouterEnv> {
     @inject(LOGGER_TOKENS.LoggerService) logger: LoggerService,
     @inject(DI_TOKENS.Application) application: Application,
   ) {
-    const trailingSlash: TrailingSlashMode = application.config.trailingSlash ?? 'ignore'
+    const trailingSlash: TrailingSlashConfig = application.config.trailingSlash ?? 'ignore'
 
     super({
       // Always non-strict: a registered `/foo` route matches both `/foo` and `/foo/`.

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -4,7 +4,7 @@
 // Core router types
 export type { IController } from './controller'
 export type { Middleware, Next } from './middleware.interface'
-export type { ControllerOptions, ConventionRouteMetadata, ExplicitRouteMetadata, LocalePathConfig, LocaleUrlConfig, RouteBody, RouteBodyObject, RouteConfig, RouteMetadata, RouterEnv, RouteResponse, RouteResponseObject, RouterVariables, SecurityScheme, TrailingSlashMode, VersioningOptions } from './types'
+export type { ControllerOptions, ConventionRouteMetadata, ExplicitRouteMetadata, LocalePathConfig, LocaleUrlConfig, RouteBody, RouteBodyObject, RouteConfig, RouteMetadata, RouterEnv, RouteResponse, RouteResponseObject, RouterVariables, SecurityScheme, TrailingSlashConfig, TrailingSlashExclude, TrailingSlashMode, TrailingSlashOptions, VersioningOptions } from './types'
 
 // Router constants
 export { HTTP_METHODS, ROUTE_METADATA_KEYS, ROUTER_CONTEXT_KEYS, SECURITY_SCHEMES, VERSION_NEUTRAL } from './constants'
@@ -38,7 +38,7 @@ export type { CurrentRoute, RouteMatcher, RouteName, RouteParams, RoutePrefixes,
 export { route } from './route-url'
 export { buildRouteUrl, Uri, type SignedUriOptions, type UriOptions } from './uri'
 export { applyLocalePrefix, shouldPrefixLocale, stripLocalePrefix } from './locale-url'
-export { applyTrailingSlash } from './trailing-slash'
+export { applyTrailingSlash, isTrailingSlashExcluded, resolveTrailingSlash } from './trailing-slash'
 
 // Router (replaces MiddlewareConfigurable — route + middleware configuration)
 export { Router, type RouteConfigurable, type RouterGroupConfig } from './router'

--- a/packages/core/src/router/middleware/trailing-slash-redirect.ts
+++ b/packages/core/src/router/middleware/trailing-slash-redirect.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
-import { applyTrailingSlash } from '../trailing-slash'
-import type { RouterEnv, TrailingSlashMode } from '../types'
+import { applyTrailingSlash, resolveTrailingSlash } from '../trailing-slash'
+import type { RouterEnv, TrailingSlashConfig } from '../types'
 
 const REDIRECT_STATUS = 308
 
@@ -13,6 +13,9 @@ const REDIRECT_STATUS = 308
  *   Paths whose last segment contains `.` (e.g. `/api/openapi.json`) are skipped.
  * - `'never'`  — trailing requests redirect to the non-trailing form.
  *
+ * Paths in the config's `exclude` list are never redirected — both forms
+ * are served as requested (routes match either, `strict: false`).
+ *
  * Root (`/`) is always passed through unchanged.
  *
  * 308 is used so that POST/PUT/PATCH bodies survive the redirect.
@@ -23,13 +26,13 @@ const REDIRECT_STATUS = 308
  * HTTP-speaking backend (which would otherwise produce a mixed-content block).
  */
 export function createTrailingSlashRedirect(
-  mode: TrailingSlashMode,
+  config: TrailingSlashConfig,
 ): MiddlewareHandler<RouterEnv> | null {
-  if (mode === 'ignore') return null
+  if (resolveTrailingSlash(config).mode === 'ignore') return null
 
   return async (c, next) => {
     const url = new URL(c.req.url)
-    const canonicalPath = applyTrailingSlash(url.pathname, mode)
+    const canonicalPath = applyTrailingSlash(url.pathname, config)
     if (canonicalPath === url.pathname) return next()
     return c.redirect(`${canonicalPath}${url.search}`, REDIRECT_STATUS)
   }

--- a/packages/core/src/router/middleware/trailing-slash-redirect.ts
+++ b/packages/core/src/router/middleware/trailing-slash-redirect.ts
@@ -14,7 +14,10 @@ const REDIRECT_STATUS = 308
  * - `'never'`  — trailing requests redirect to the non-trailing form.
  *
  * Paths in the config's `exclude` list are never redirected — both forms
- * are served as requested (routes match either, `strict: false`).
+ * are served as requested (routes match either, `strict: false`). When
+ * `getLocales` is provided, exclusions also match locale-prefixed request
+ * paths (`/fr/callback` for exclude `'/callback'`). It is a thunk because
+ * the middleware is created before the i18n module resolves its locales.
  *
  * Root (`/`) is always passed through unchanged.
  *
@@ -27,12 +30,14 @@ const REDIRECT_STATUS = 308
  */
 export function createTrailingSlashRedirect(
   config: TrailingSlashConfig,
+  getLocales?: () => readonly string[] | undefined,
 ): MiddlewareHandler<RouterEnv> | null {
-  if (resolveTrailingSlash(config).mode === 'ignore') return null
+  const options = resolveTrailingSlash(config)
+  if (options.mode === 'ignore') return null
 
   return async (c, next) => {
     const url = new URL(c.req.url)
-    const canonicalPath = applyTrailingSlash(url.pathname, config)
+    const canonicalPath = applyTrailingSlash(url.pathname, options, getLocales?.())
     if (canonicalPath === url.pathname) return next()
     return c.redirect(`${canonicalPath}${url.search}`, REDIRECT_STATUS)
   }

--- a/packages/core/src/router/trailing-slash.ts
+++ b/packages/core/src/router/trailing-slash.ts
@@ -1,3 +1,4 @@
+import { stripLocalePrefix } from './locale-url'
 import type { TrailingSlashConfig, TrailingSlashExclude, TrailingSlashOptions } from './types'
 
 /** Normalise the `trailingSlash` config (bare mode or `{ mode, exclude }`). */
@@ -7,21 +8,43 @@ export function resolveTrailingSlash(config: TrailingSlashConfig | undefined): T
   return config
 }
 
+/** Strip a single trailing `/` from a path. Root (`/`) is left untouched. */
+const stripTrailingSlash = (path: string): string =>
+  path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+
 /**
  * Whether a pathname is exempt from trailing-slash canonicalisation.
- * String patterns are segment-aware prefixes; RegExps test the pathname.
- * Both forms of the path (with and without the trailing slash) are exempt.
+ *
+ * String patterns are segment-aware prefixes. RegExps are tested against
+ * both forms of the pathname (with and without the trailing slash), so a
+ * pattern anchored to either form exempts both — same guarantee as strings.
+ *
+ * When `locales` is given (path-based locale detection), a leading locale
+ * segment is stripped and the bare path matched too, so `'/callback'` also
+ * exempts `/fr/callback` — exclusions are written in route space, like the
+ * routes themselves.
  */
 export function isTrailingSlashExcluded(
   pathname: string,
   exclude: readonly TrailingSlashExclude[] | undefined,
+  locales?: readonly string[],
 ): boolean {
   if (!exclude?.length) return false
-  const bare = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
-  return exclude.some((pattern) => {
-    if (typeof pattern !== 'string') return pattern.test(pathname)
-    const prefix = pattern.length > 1 && pattern.endsWith('/') ? pattern.slice(0, -1) : pattern
-    return bare === prefix || bare.startsWith(`${prefix}/`)
+
+  const candidates = [pathname]
+  if (locales?.length) {
+    const stripped = stripLocalePrefix(pathname, locales)
+    if (stripped !== pathname) candidates.push(stripped)
+  }
+
+  return candidates.some((candidate) => {
+    const bare = stripTrailingSlash(candidate)
+    const slashed = bare === '/' ? bare : `${bare}/`
+    return exclude.some((pattern) => {
+      if (typeof pattern !== 'string') return pattern.test(bare) || pattern.test(slashed)
+      const prefix = stripTrailingSlash(pattern)
+      return bare === prefix || bare.startsWith(`${prefix}/`)
+    })
   })
 }
 
@@ -36,7 +59,9 @@ export function isTrailingSlashExcluded(
  *
  * Paths matching the config's `exclude` list are returned as-is — their
  * canonical form is owned elsewhere (e.g. an OAuth redirect URI registered
- * with an IdP and matched byte-for-byte).
+ * with an IdP and matched byte-for-byte). Pass `locales` when path-based
+ * locale detection is active so locale-prefixed forms of excluded paths are
+ * exempt too (see {@link isTrailingSlashExcluded}).
  *
  * Preserves query string and hash. Handles both relative paths
  * (`/foo?x=1`) and absolute URLs (`https://host/foo?x=1`).
@@ -44,7 +69,7 @@ export function isTrailingSlashExcluded(
  * Used by URL-generation helpers and the redirect middleware so canonical
  * form is computed in one place.
  */
-export function applyTrailingSlash(url: string, config: TrailingSlashConfig): string {
+export function applyTrailingSlash(url: string, config: TrailingSlashConfig, locales?: readonly string[]): string {
   const { mode, exclude } = resolveTrailingSlash(config)
   if (mode === 'ignore') return url
 
@@ -55,7 +80,7 @@ export function applyTrailingSlash(url: string, config: TrailingSlashConfig): st
 
   const path = parsed.pathname
   if (path === '/') return url
-  if (isTrailingSlashExcluded(path, exclude)) return url
+  if (isTrailingSlashExcluded(path, exclude, locales)) return url
 
   const hasTrailing = path.endsWith('/')
 

--- a/packages/core/src/router/trailing-slash.ts
+++ b/packages/core/src/router/trailing-slash.ts
@@ -1,7 +1,32 @@
-import type { TrailingSlashMode } from './types'
+import type { TrailingSlashConfig, TrailingSlashExclude, TrailingSlashOptions } from './types'
+
+/** Normalise the `trailingSlash` config (bare mode or `{ mode, exclude }`). */
+export function resolveTrailingSlash(config: TrailingSlashConfig | undefined): TrailingSlashOptions {
+  if (!config) return { mode: 'ignore' }
+  if (typeof config === 'string') return { mode: config }
+  return config
+}
 
 /**
- * Apply a trailing-slash mode to a URL or path.
+ * Whether a pathname is exempt from trailing-slash canonicalisation.
+ * String patterns are segment-aware prefixes; RegExps test the pathname.
+ * Both forms of the path (with and without the trailing slash) are exempt.
+ */
+export function isTrailingSlashExcluded(
+  pathname: string,
+  exclude: readonly TrailingSlashExclude[] | undefined,
+): boolean {
+  if (!exclude?.length) return false
+  const bare = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+  return exclude.some((pattern) => {
+    if (typeof pattern !== 'string') return pattern.test(pathname)
+    const prefix = pattern.length > 1 && pattern.endsWith('/') ? pattern.slice(0, -1) : pattern
+    return bare === prefix || bare.startsWith(`${prefix}/`)
+  })
+}
+
+/**
+ * Apply a trailing-slash config to a URL or path.
  *
  * - `'ignore'` — return as-is.
  * - `'always'` — append `/` to the pathname unless it already has one.
@@ -9,13 +34,18 @@ import type { TrailingSlashMode } from './types'
  *   root `/` path.
  * - `'never'`  — strip a trailing `/` from the pathname. Skipped for root.
  *
+ * Paths matching the config's `exclude` list are returned as-is — their
+ * canonical form is owned elsewhere (e.g. an OAuth redirect URI registered
+ * with an IdP and matched byte-for-byte).
+ *
  * Preserves query string and hash. Handles both relative paths
  * (`/foo?x=1`) and absolute URLs (`https://host/foo?x=1`).
  *
  * Used by URL-generation helpers and the redirect middleware so canonical
  * form is computed in one place.
  */
-export function applyTrailingSlash(url: string, mode: TrailingSlashMode): string {
+export function applyTrailingSlash(url: string, config: TrailingSlashConfig): string {
+  const { mode, exclude } = resolveTrailingSlash(config)
   if (mode === 'ignore') return url
 
   const isAbsolute = /^https?:\/\//i.test(url)
@@ -25,6 +55,7 @@ export function applyTrailingSlash(url: string, mode: TrailingSlashMode): string
 
   const path = parsed.pathname
   if (path === '/') return url
+  if (isTrailingSlashExcluded(path, exclude)) return url
 
   const hasTrailing = path.endsWith('/')
 

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -257,7 +257,12 @@ export type TrailingSlashMode = 'ignore' | 'always' | 'never'
  * - `string` — matches that exact path and any subpath, segment-aware:
  *   `'/auth/oauth2'` exempts `/auth/oauth2` and `/auth/oauth2/callback/x`,
  *   but not `/auth/oauth2-other`.
- * - `RegExp` — tested against the request/generated pathname.
+ * - `RegExp` — tested against both forms of the pathname (with and without
+ *   the trailing slash), so a pattern anchored to either form exempts both.
+ *
+ * Both kinds match in route space: when path-based locale detection is on,
+ * a leading locale segment is stripped before matching, so `'/callback'`
+ * also exempts `/fr/callback`.
  */
 export type TrailingSlashExclude = string | RegExp
 

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -252,6 +252,31 @@ export interface ControllerOptions {
 export type TrailingSlashMode = 'ignore' | 'always' | 'never'
 
 /**
+ * A path exempt from trailing-slash canonicalisation.
+ *
+ * - `string` — matches that exact path and any subpath, segment-aware:
+ *   `'/auth/oauth2'` exempts `/auth/oauth2` and `/auth/oauth2/callback/x`,
+ *   but not `/auth/oauth2-other`.
+ * - `RegExp` — tested against the request/generated pathname.
+ */
+export type TrailingSlashExclude = string | RegExp
+
+/**
+ * Trailing-slash handling with exclusions. Excluded paths are left exactly
+ * as requested/authored by BOTH the 308 redirect middleware and URL
+ * generation (`route()` and friends) — for routes whose canonical form is
+ * dictated by an external party (e.g. an OAuth redirect URI registered with
+ * an IdP, matched byte-for-byte).
+ */
+export interface TrailingSlashOptions {
+  mode: TrailingSlashMode
+  exclude?: readonly TrailingSlashExclude[]
+}
+
+/** `trailingSlash` application config: a bare mode, or `{ mode, exclude }`. */
+export type TrailingSlashConfig = TrailingSlashMode | TrailingSlashOptions
+
+/**
  * Versioning configuration for the application.
  * Enables URI-based API versioning when provided to Stratal config.
  */

--- a/packages/core/src/router/uri.ts
+++ b/packages/core/src/router/uri.ts
@@ -11,7 +11,7 @@ import { ROUTER_TOKENS } from './router.tokens';
 import type { LocalePathService } from './services/locale-path.service';
 import { signUrl, verifySignedUrl, type SignedUrlOptions } from './signed-url';
 import { applyTrailingSlash } from './trailing-slash';
-import type { LocaleUrlConfig, TrailingSlashMode } from './types';
+import type { LocaleUrlConfig, TrailingSlashConfig } from './types';
 
 /**
  * Options for URL generation methods.
@@ -132,7 +132,7 @@ export function buildRouteUrl(
 @Request(ROUTER_TOKENS.Uri)
 export class Uri {
   private _defaults: Record<string, string> = {}
-  private readonly trailingSlash: TrailingSlashMode
+  private readonly trailingSlash: TrailingSlashConfig
   private readonly localeConfig: LocaleUrlConfig
 
   constructor(

--- a/packages/core/src/router/uri.ts
+++ b/packages/core/src/router/uri.ts
@@ -10,8 +10,8 @@ import { RouterError } from './router.error';
 import { ROUTER_TOKENS } from './router.tokens';
 import type { LocalePathService } from './services/locale-path.service';
 import { signUrl, verifySignedUrl, type SignedUrlOptions } from './signed-url';
-import { applyTrailingSlash } from './trailing-slash';
-import type { LocaleUrlConfig, TrailingSlashConfig } from './types';
+import { applyTrailingSlash, resolveTrailingSlash } from './trailing-slash';
+import type { LocaleUrlConfig, TrailingSlashOptions } from './types';
 
 /**
  * Options for URL generation methods.
@@ -132,7 +132,8 @@ export function buildRouteUrl(
 @Request(ROUTER_TOKENS.Uri)
 export class Uri {
   private _defaults: Record<string, string> = {}
-  private readonly trailingSlash: TrailingSlashConfig
+  private readonly trailingSlash: TrailingSlashOptions
+  private readonly locales?: readonly string[]
   private readonly localeConfig: LocaleUrlConfig
 
   constructor(
@@ -141,7 +142,9 @@ export class Uri {
     @inject(DI_TOKENS.Application) application: Application,
     @inject(ROUTER_TOKENS.LocalePathService) localePathService: LocalePathService,
   ) {
-    this.trailingSlash = application.config.trailingSlash ?? 'ignore'
+    // Resolved once — applyTrailingSlash accepts the resolved form directly.
+    this.trailingSlash = resolveTrailingSlash(application.config.trailingSlash)
+    this.locales = localePathService.localePathConfig?.allLocales
     this.localeConfig = {
       defaultLocale: localePathService.localePathConfig?.defaultLocale ?? null,
       prefixDefaultLocale: localePathService.prefixDefaultLocale,
@@ -191,7 +194,7 @@ export class Uri {
     }
 
     const mergedParams = { ...this._defaults, ...params } as Record<string, string>
-    let url = applyTrailingSlash(buildRouteUrl(registeredRoute, name, mergedParams, this.localeConfig), this.trailingSlash)
+    let url = applyTrailingSlash(buildRouteUrl(registeredRoute, name, mergedParams, this.localeConfig), this.trailingSlash, this.locales)
 
     if (options?.absolute && !url.startsWith('http')) {
       const origin = new URL(this.routerContext.c.req.url).origin
@@ -248,7 +251,7 @@ export class Uri {
    */
   current(): string {
     const parsed = new URL(this.routerContext.c.req.url)
-    return applyTrailingSlash(parsed.pathname, this.trailingSlash)
+    return applyTrailingSlash(parsed.pathname, this.trailingSlash, this.locales)
   }
 
   /**
@@ -256,7 +259,7 @@ export class Uri {
    */
   full(): string {
     const parsed = new URL(this.routerContext.c.req.url)
-    return applyTrailingSlash(`${parsed.pathname}${parsed.search}`, this.trailingSlash)
+    return applyTrailingSlash(`${parsed.pathname}${parsed.search}`, this.trailingSlash, this.locales)
   }
 
   /**
@@ -293,7 +296,7 @@ export class Uri {
    * @param options - URL generation options
    */
   to(path: string, queryParams?: Record<string, string>, options?: UriOptions): string {
-    let url = applyTrailingSlash(path, this.trailingSlash)
+    let url = applyTrailingSlash(path, this.trailingSlash, this.locales)
 
     if (queryParams) {
       const entries = Object.entries(queryParams)
@@ -324,7 +327,7 @@ export class Uri {
     for (const [key, value] of Object.entries(queryParams)) {
       parsed.searchParams.set(key, value)
     }
-    return applyTrailingSlash(`${parsed.pathname}${parsed.search}`, this.trailingSlash)
+    return applyTrailingSlash(`${parsed.pathname}${parsed.search}`, this.trailingSlash, this.locales)
   }
 
   private getAppSecret(): string {

--- a/packages/inertia/src/__tests__/hreflang.service.spec.ts
+++ b/packages/inertia/src/__tests__/hreflang.service.spec.ts
@@ -1,7 +1,7 @@
 import type { Application } from 'stratal'
 import { DI_TOKENS } from 'stratal/di'
 import { I18N_TOKENS, type I18nModuleOptions } from 'stratal/i18n'
-import { ROUTER_TOKENS, type LocaleUrlService } from 'stratal/router'
+import { ROUTER_TOKENS, type LocaleUrlService, type TrailingSlashConfig } from 'stratal/router'
 import { describe, expect, it } from 'vitest'
 import { HreflangService } from '../services/hreflang.service'
 
@@ -15,7 +15,7 @@ interface StubOptions {
   i18n?: I18nModuleOptions
   /** When provided, simulates path-based locale detection being active. */
   pathConfig?: { allLocales: string[]; defaultLocale: string | null; prefixDefaultLocale: false | true | 'redirect' }
-  trailingSlash?: 'always' | 'never' | 'ignore'
+  trailingSlash?: TrailingSlashConfig
 }
 
 function createService(stub: StubOptions): HreflangService {
@@ -202,6 +202,16 @@ describe('HreflangService', () => {
       const service = createService({ ...base, trailingSlash: 'ignore' })
       const links = service.buildLinks(new URL('http://localhost/users'))
       expect(links[0]).toEqual(alt('en', 'http://localhost/users'))
+    })
+
+    it('exempts excluded paths — including locale-prefixed variants', () => {
+      const service = createService({ ...base, trailingSlash: { mode: 'always', exclude: ['/users'] } })
+      const links = service.buildLinks(new URL('http://localhost/users'))
+      expect(links).toEqual([
+        alt('en', 'http://localhost/users'),
+        alt('fr', 'http://localhost/fr/users'),
+        alt('x-default', 'http://localhost/users'),
+      ])
     })
   })
 })

--- a/packages/inertia/src/__tests__/inertia.service.spec.ts
+++ b/packages/inertia/src/__tests__/inertia.service.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@inertiajs/core'
 import type { Context } from 'hono'
 import type { Application } from 'stratal'
 import { DI_TOKENS } from 'stratal/di'
-import { ROUTER_CONTEXT_KEYS, ROUTER_TOKENS, RouterContext, type RegisteredRoute, type RouteRegistry, type TrailingSlashMode } from 'stratal/router'
+import { ROUTER_CONTEXT_KEYS, ROUTER_TOKENS, RouterContext, type RegisteredRoute, type RouteRegistry, type TrailingSlashConfig } from 'stratal/router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { InertiaModuleOptions } from '../inertia.options'
 import { InertiaService } from '../services/inertia.service'
@@ -20,7 +20,7 @@ function createMockContext(overrides: {
   isInertia?: boolean
   withoutSsr?: boolean
   routes?: RegisteredRoute[]
-  trailingSlash?: TrailingSlashMode
+  trailingSlash?: TrailingSlashConfig
   routePath?: string
   validatedParams?: Record<string, string>
   defaults?: Record<string, string>
@@ -655,6 +655,26 @@ describe('InertiaService', () => {
       const response = await routesService.render(ctx, 'Home', {})
       const body = await parsePageJson(response)
 
+      expect(body.props.trailingSlash).toBe('always')
+    })
+
+    it('shares only the resolved mode when trailingSlash has exclusions', async () => {
+      const routesOptions: InertiaModuleOptions = {
+        rootView: '<html>@inertia</html>',
+        version: '1.0',
+        routes: true,
+      }
+      const routesService = new InertiaService(routesOptions, mockTemplate, mockSsr, mockSeo)
+      const ctx = createMockContext({
+        isInertia: true,
+        routes: [sampleRoute],
+        trailingSlash: { mode: 'always', exclude: ['/callback', /^\/webhooks\//] },
+      })
+
+      const response = await routesService.render(ctx, 'Home', {})
+      const body = await parsePageJson(response)
+
+      // Exclusions are server-side only — RegExp patterns don't survive JSON.
       expect(body.props.trailingSlash).toBe('always')
     })
 

--- a/packages/inertia/src/services/hreflang.service.ts
+++ b/packages/inertia/src/services/hreflang.service.ts
@@ -2,7 +2,7 @@ import type { Application } from 'stratal'
 import { CONTAINER_TOKEN, type Container, DI_TOKENS, Singleton, inject } from 'stratal/di'
 import { I18N_TOKENS } from 'stratal/i18n'
 import type { I18nModuleOptions } from 'stratal/i18n'
-import { ROUTER_TOKENS, applyTrailingSlash, type LocaleUrlService, type TrailingSlashMode } from 'stratal/router'
+import { ROUTER_TOKENS, applyTrailingSlash, type LocaleUrlService, type TrailingSlashConfig } from 'stratal/router'
 import type { SeoLinkTag } from '../seo/types'
 
 /**
@@ -22,8 +22,8 @@ import type { SeoLinkTag } from '../seo/types'
  * navigation) as the rest of the SEO tags — no separate head path.
  *
  * Every generated `href` runs through {@link applyTrailingSlash} with the
- * app-wide mode so hreflang URLs match the canonical form the rest of the
- * router emits.
+ * app-wide config (mode + exclusions) so hreflang URLs match the canonical
+ * form the rest of the router emits.
  */
 @Singleton()
 export class HreflangService {
@@ -39,7 +39,7 @@ export class HreflangService {
     const defaultLocale = i18n.defaultLocale ?? 'en'
 
     const app = this.container.resolve<Application>(DI_TOKENS.Application)
-    const trailingSlash: TrailingSlashMode = app.config.trailingSlash ?? 'ignore'
+    const trailingSlash: TrailingSlashConfig = app.config.trailingSlash ?? 'ignore'
 
     const localeUrl = this.container.resolve<LocaleUrlService>(ROUTER_TOKENS.LocaleUrlService)
     if (localeUrl.pathEnabled) {
@@ -59,13 +59,13 @@ export class HreflangService {
     locales: string[],
     defaultLocale: string,
     localeUrl: LocaleUrlService,
-    trailingSlash: TrailingSlashMode,
+    trailingSlash: TrailingSlashConfig,
   ): SeoLinkTag[] {
     const basePath = localeUrl.stripPrefix(url.pathname)
     const links = locales.map((locale) =>
-      this.linkTag(locale, this.compose(url, localeUrl.applyPrefix(basePath, locale), url.search, trailingSlash)),
+      this.linkTag(locale, this.compose(url, localeUrl.applyPrefix(basePath, locale), url.search, trailingSlash, locales)),
     )
-    links.push(this.linkTag('x-default', this.compose(url, localeUrl.applyPrefix(basePath, defaultLocale), url.search, trailingSlash)))
+    links.push(this.linkTag('x-default', this.compose(url, localeUrl.applyPrefix(basePath, defaultLocale), url.search, trailingSlash, locales)))
     return links
   }
 
@@ -73,7 +73,7 @@ export class HreflangService {
     url: URL,
     locales: string[],
     defaultLocale: string,
-    trailingSlash: TrailingSlashMode,
+    trailingSlash: TrailingSlashConfig,
   ): SeoLinkTag[] {
     const params = new URLSearchParams(url.search)
     params.delete('locale')
@@ -87,8 +87,8 @@ export class HreflangService {
     return links
   }
 
-  private compose(url: URL, pathname: string, search: string, mode: TrailingSlashMode): string {
-    return applyTrailingSlash(url.origin + pathname + search, mode)
+  private compose(url: URL, pathname: string, search: string, config: TrailingSlashConfig, locales?: readonly string[]): string {
+    return applyTrailingSlash(url.origin + pathname + search, config, locales)
   }
 
   private composeQuery(baseQs: string, extra: [string, string] | null): string {

--- a/packages/inertia/src/services/inertia.service.ts
+++ b/packages/inertia/src/services/inertia.service.ts
@@ -2,7 +2,7 @@ import type { Page } from '@inertiajs/core'
 import type { Application } from 'stratal'
 import { DI_TOKENS, Request, inject } from 'stratal/di'
 import { I18N_TOKENS, type MessageLoaderService } from 'stratal/i18n'
-import { ROUTER_TOKENS, type CurrentRoute, type LocalePathService, type LocaleUrlConfig, type RegisteredRoute, type RouteRegistry, type RouterContext, type SerializedRoutes, type Uri } from 'stratal/router'
+import { ROUTER_TOKENS, resolveTrailingSlash, type CurrentRoute, type LocalePathService, type LocaleUrlConfig, type RegisteredRoute, type RouteRegistry, type RouterContext, type SerializedRoutes, type Uri } from 'stratal/router'
 import type { InertiaMergeOptions, InertiaOnceOptions } from '../augment/router-context'
 import type { InertiaModuleOptions } from '../inertia.options'
 import { INERTIA_TOKENS } from '../inertia.tokens'
@@ -219,7 +219,10 @@ export class InertiaService {
       const localePathService = container.resolve<LocalePathService>(ROUTER_TOKENS.LocalePathService)
 
       shared.routes = this.serializeRoutes(registry.named())
-      shared.trailingSlash = application.config.trailingSlash ?? 'ignore'
+      // Share the resolved mode only — exclusions are server-side (RegExp
+      // patterns don't survive JSON). Excluded paths are served in both slash
+      // forms by the server, so a client-canonicalised URL never redirects.
+      shared.trailingSlash = resolveTrailingSlash(application.config.trailingSlash).mode
       shared.route = { name, params, defaults: uri.getDefaults() } satisfies CurrentRoute
       shared.localeConfig = {
         defaultLocale: localePathService.localePathConfig?.defaultLocale ?? null,


### PR DESCRIPTION
## Summary
`trailingSlash` now accepts `{ mode, exclude }` so paths whose canonical form is owned externally (e.g. OAuth redirect URIs matched byte-for-byte by an IdP) are exempt from 308 redirects and URL-generation rewriting. Exclusions match in route space â with path-based locale detection, `'/callback'` also exempts `/fr/callback`.

- String patterns are segment-aware prefixes; RegExps match both slash forms regardless of anchoring
- Redirect middleware reads locales lazily (i18n initialises after `HonoApp`)
- `Uri` helpers and `@stratal/inertia` hreflang links honour exclusions
- Inertia shares only the resolved mode with the client (RegExps don't survive JSON; server serves both forms, so client URLs never redirect)
- New `stratal/router` exports: `resolveTrailingSlash`, `isTrailingSlashExcluded`, `TrailingSlashConfig` / `TrailingSlashOptions` / `TrailingSlashExclude` types

## How to Test
- `yarn workspace stratal test src/router/__tests__/trailing-slash.spec.ts src/router/__tests__/uri.spec.ts`
- `yarn workspace @stratal/inertia test`
- Configure `trailingSlash: { mode: 'always', exclude: ['/callback'] }` â `/callback` and `/callback/` both serve 200, `/users` still 308s to `/users/`
- With path locales enabled, verify `/fr/callback` is also exempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trailing slash configuration now accepts an object form with path exclusions, allowing specified routes to serve both slash variants without canonicalization redirects while other routes follow the configured trailing-slash mode.

* **Documentation**
  * Updated configuration documentation with details on the new exclusion feature and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->