### PR TITLE
fix(core): derive the dev registry from the project root in quarry

### DIFF
--- a/packages/core/src/bin/__tests__/registry.spec.ts
+++ b/packages/core/src/bin/__tests__/registry.spec.ts
@@ -1,0 +1,118 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findProjectRoot, resolveDevRegistryPath } from '../registry'
+
+const cleanups: string[] = []
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'quarry-registry-'))
+  cleanups.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of cleanups.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('findProjectRoot', () => {
+  it.each(['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'bun.lock', 'bun.lockb'])(
+    'finds the nearest ancestor containing %s',
+    (lockfile) => {
+      const root = makeFixture()
+      writeFileSync(join(root, lockfile), '')
+      const nested = join(root, 'apps', 'data-plane')
+      mkdirSync(nested, { recursive: true })
+
+      expect(findProjectRoot(nested)).toBe(root)
+    },
+  )
+
+  it('prefers the lockfile root over nested workspace package.json files', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    writeFileSync(join(root, 'package.json'), '{}')
+    const nested = join(root, 'apps', 'data-plane')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'package.json'), '{}')
+
+    expect(findProjectRoot(nested)).toBe(root)
+  })
+
+  it('is not fooled by stray .git directories inside the workspace', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    const nested = join(root, 'apps', 'data-plane')
+    mkdirSync(join(nested, '.git'), { recursive: true })
+
+    expect(findProjectRoot(nested)).toBe(root)
+  })
+
+  it('keeps a nested checkout with its own lockfile isolated from the outer one', () => {
+    const outer = makeFixture()
+    writeFileSync(join(outer, 'yarn.lock'), '')
+    const inner = join(outer, '.claude', 'worktrees', 'fix')
+    mkdirSync(inner, { recursive: true })
+    writeFileSync(join(inner, 'yarn.lock'), '')
+    const nested = join(inner, 'apps', 'data-plane')
+    mkdirSync(nested, { recursive: true })
+
+    expect(findProjectRoot(nested)).toBe(inner)
+  })
+
+  it('returns the start directory itself when it holds the lockfile', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'yarn.lock'), '')
+
+    expect(findProjectRoot(root)).toBe(root)
+  })
+
+  it('uses the outermost package.json when no lockfile exists', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'package.json'), '{}')
+    const nested = join(root, 'apps', 'data-plane')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'package.json'), '{}')
+
+    expect(findProjectRoot(nested)).toBe(root)
+  })
+
+  it('returns undefined when no marker is found', () => {
+    const dir = makeFixture()
+
+    expect(findProjectRoot(dir)).toBeUndefined()
+  })
+})
+
+describe('resolveDevRegistryPath', () => {
+  it('honours an explicit MINIFLARE_REGISTRY_PATH', () => {
+    expect(resolveDevRegistryPath({ MINIFLARE_REGISTRY_PATH: '/explicit/mf' }, '/anywhere')).toBe('/explicit/mf')
+  })
+
+  it('honours an explicit WRANGLER_REGISTRY_PATH', () => {
+    expect(resolveDevRegistryPath({ WRANGLER_REGISTRY_PATH: '/explicit/wr' }, '/anywhere')).toBe('/explicit/wr')
+  })
+
+  it('prefers MINIFLARE_REGISTRY_PATH when both are set', () => {
+    const env = { MINIFLARE_REGISTRY_PATH: '/explicit/mf', WRANGLER_REGISTRY_PATH: '/explicit/wr' }
+
+    expect(resolveDevRegistryPath(env, '/anywhere')).toBe('/explicit/mf')
+  })
+
+  it('derives <projectRoot>/.wrangler/registry from the lockfile root', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    const nested = join(root, 'apps', 'data-plane')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'package.json'), '{}')
+
+    expect(resolveDevRegistryPath({}, nested)).toBe(join(root, '.wrangler', 'registry'))
+  })
+
+  it('falls back to <cwd>/.wrangler/registry when no marker is found', () => {
+    const dir = makeFixture()
+
+    expect(resolveDevRegistryPath({}, dir)).toBe(join(dir, '.wrangler', 'registry'))
+  })
+})

--- a/packages/core/src/bin/__tests__/registry.spec.ts
+++ b/packages/core/src/bin/__tests__/registry.spec.ts
@@ -61,6 +61,22 @@ describe('findProjectRoot', () => {
     expect(findProjectRoot(nested)).toBe(inner)
   })
 
+  it('terminates and returns an absolute root for a relative start directory', () => {
+    const root = makeFixture()
+    writeFileSync(join(root, 'yarn.lock'), '')
+    mkdirSync(join(root, 'apps', 'data-plane'), { recursive: true })
+
+    const previousCwd = process.cwd()
+    process.chdir(root)
+    try {
+      // Pre-normalization this either hung (no marker reachable relatively) or
+      // returned a relative '.' — assert the absolute lockfile root instead.
+      expect(findProjectRoot(join('apps', 'data-plane'))).toBe(process.cwd())
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
   it('returns the start directory itself when it holds the lockfile', () => {
     const root = makeFixture()
     writeFileSync(join(root, 'yarn.lock'), '')

--- a/packages/core/src/bin/quarry.ts
+++ b/packages/core/src/bin/quarry.ts
@@ -7,6 +7,7 @@ import type { QuarryRegistry } from 'stratal/quarry';
 import { type Application } from '../application';
 import { extractEnvFlag } from './argv';
 import { createDynamicCommands } from './commands/dynamic-command';
+import { resolveDevRegistryPath } from './registry';
 
 interface WranglerConfig {
   name?: string
@@ -25,7 +26,6 @@ interface WranglerModule {
 
 interface MiniflareModule {
   Miniflare: new (opts: MiniflareOptions) => { ready: Promise<URL>; getBindings: (name?: string) => Promise<Record<string, unknown>>; dispose: () => Promise<void> }
-  getDefaultDevRegistryPath: () => string
 }
 
 const require = createRequire(import.meta.url)
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
   const cwdRequire = createRequire(join(process.cwd(), 'package.json'))
 
   const { unstable_readConfig: readConfig, unstable_getMiniflareWorkerOptions: getMiniflareWorkerOptions, unstable_getVarsForDev: getVarsForDev } = await import(cwdRequire.resolve('wrangler')) as WranglerModule
-  const { Miniflare, getDefaultDevRegistryPath } = await import(cwdRequire.resolve('miniflare')) as MiniflareModule
+  const { Miniflare } = await import(cwdRequire.resolve('miniflare')) as MiniflareModule
 
   const candidates = ['wrangler.jsonc', 'wrangler.json', 'wrangler.toml']
   const configName = candidates.find(c => existsSync(resolve(process.cwd(), c)))
@@ -96,20 +96,24 @@ async function main(): Promise<void> {
     if (existsSync(envPath)) process.loadEnvFile(envPath)
   }
 
-  // Bridge the documented `WRANGLER_REGISTRY_PATH` to `MINIFLARE_REGISTRY_PATH`,
-  // the variable Miniflare's `getDefaultDevRegistryPath()` actually reads.
-  // `wrangler dev` performs the same translation internally; mirroring it here
-  // lets a single documented env var redirect the dev service registry for BOTH
-  // this CLI's Miniflare (below) AND any vite dev server a command launches
-  // (`@cloudflare/vite-plugin` also resolves its registry via
-  // `getDefaultDevRegistryPath()`). That allows several isolated dev environments
-  // to run in parallel without sharing the global `~/.wrangler/registry`, where
-  // their identically-named workers would otherwise overwrite each other and
-  // break cross-worker service-binding resolution. Only set when unset so an
-  // explicit override still wins.
-  if (process.env.WRANGLER_REGISTRY_PATH && !process.env.MINIFLARE_REGISTRY_PATH) {
-    process.env.MINIFLARE_REGISTRY_PATH = process.env.WRANGLER_REGISTRY_PATH
-  }
+  // Deterministically resolve the dev service registry from the project root
+  // (`<projectRoot>/.wrangler/registry`) so a bare `quarry` invocation shares
+  // the SAME project-local registry every other process in this checkout uses —
+  // never the global `~/.wrangler/registry`, where parallel checkouts'
+  // identically-named workers would overwrite each other and break cross-worker
+  // service-binding resolution. An explicit `WRANGLER_REGISTRY_PATH` /
+  // `MINIFLARE_REGISTRY_PATH` (from the shell or the `.env` files above) wins.
+  //
+  // Exported as `MINIFLARE_REGISTRY_PATH` — the variable Miniflare's
+  // `getDefaultDevRegistryPath()` reads at call time — so any child process a
+  // command spawns (notably the vite dev server launched by `inertia:dev`,
+  // whose `@cloudflare/vite-plugin` resolves its registry the same way) lands
+  // in the identical registry.
+  const registryPath = resolveDevRegistryPath({
+    MINIFLARE_REGISTRY_PATH: process.env.MINIFLARE_REGISTRY_PATH,
+    WRANGLER_REGISTRY_PATH: process.env.WRANGLER_REGISTRY_PATH,
+  }, process.cwd())
+  process.env.MINIFLARE_REGISTRY_PATH = registryPath
 
   const config = readConfig({ config: configPath, env: environment })
   const { workerOptions } = getMiniflareWorkerOptions(config, environment)
@@ -132,10 +136,6 @@ async function main(): Promise<void> {
   // for service binding resolution — a collision would break the running session.
   const workerName = config.name ? `quarry-${config.name}-${process.pid}` : `quarry-${process.pid}`
   workerOptions.name = workerName
-
-  // Resolve the dev-registry path so Miniflare can discover running
-  // `wrangler dev` sessions for service binding resolution.
-  const registryPath = getDefaultDevRegistryPath()
 
   const mf = new Miniflare({
     ...workerOptions,

--- a/packages/core/src/bin/registry.ts
+++ b/packages/core/src/bin/registry.ts
@@ -1,0 +1,61 @@
+import { existsSync } from 'node:fs'
+import { dirname, join, parse } from 'node:path'
+
+const LOCKFILES = [
+  'yarn.lock',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'bun.lock',
+  'bun.lockb',
+]
+
+/**
+ * Walk up from `startDir` to the project root.
+ *
+ * The root is the nearest ancestor containing a package-manager lockfile —
+ * lockfiles exist only at install roots, so the marker is immune to nested
+ * workspace `package.json`s and to stray `.git` directories tools sometimes
+ * leave behind. When no lockfile exists (e.g. a project before its first
+ * install), the outermost ancestor containing a `package.json` is used —
+ * every project has one, monorepo or not, git or not.
+ *
+ * Returns `undefined` when neither marker is found.
+ */
+export function findProjectRoot(startDir: string): string | undefined {
+  let dir = startDir
+  const { root } = parse(dir)
+  let outermostPackageJson: string | undefined
+  while (true) {
+    if (LOCKFILES.some(lockfile => existsSync(join(dir, lockfile)))) return dir
+    if (existsSync(join(dir, 'package.json'))) outermostPackageJson = dir
+    if (dir === root) return outermostPackageJson
+    dir = dirname(dir)
+  }
+}
+
+export interface DevRegistryEnv {
+  MINIFLARE_REGISTRY_PATH?: string
+  WRANGLER_REGISTRY_PATH?: string
+}
+
+/**
+ * Resolve the Miniflare dev-registry path for a quarry run.
+ *
+ * Precedence:
+ *  1. an explicit `MINIFLARE_REGISTRY_PATH` (the variable Miniflare actually
+ *     reads) or `WRANGLER_REGISTRY_PATH` (the variable `wrangler dev` reads —
+ *     honoured here too so one override redirects every tool the same way)
+ *  2. `<projectRoot>/.wrangler/registry` (see `findProjectRoot`) — so every
+ *     process in a checkout (dev servers, quarry CLI runs) deterministically
+ *     shares one registry, and parallel checkouts (git worktrees) each get
+ *     their own.
+ *
+ * The global `~/.wrangler/registry` is deliberately never used: a registry
+ * shared across checkouts lets identically-named workers from parallel dev
+ * environments overwrite each other and breaks service-binding resolution.
+ */
+export function resolveDevRegistryPath(env: DevRegistryEnv, cwd: string): string {
+  const explicit = env.MINIFLARE_REGISTRY_PATH ?? env.WRANGLER_REGISTRY_PATH
+  if (explicit) return explicit
+  return join(findProjectRoot(cwd) ?? cwd, '.wrangler', 'registry')
+}

--- a/packages/core/src/bin/registry.ts
+++ b/packages/core/src/bin/registry.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { dirname, join, parse } from 'node:path'
+import { dirname, join, parse, resolve } from 'node:path'
 
 const LOCKFILES = [
   'yarn.lock',
@@ -22,7 +22,10 @@ const LOCKFILES = [
  * Returns `undefined` when neither marker is found.
  */
 export function findProjectRoot(startDir: string): string | undefined {
-  let dir = startDir
+  // A relative `startDir` would never equal its parsed root (`''`) — `dirname`
+  // converges to `'.'` and the walk never terminates. Resolve up front so the
+  // traversal (and the returned path) is always absolute.
+  let dir = resolve(startDir)
   const { root } = parse(dir)
   let outermostPackageJson: string | undefined
   while (true) {


### PR DESCRIPTION
## Summary

A bare `quarry` invocation previously resolved its Miniflare dev-service registry via `getDefaultDevRegistryPath()`, falling back to the global `~/.wrangler/registry` — so identically-named workers from parallel checkouts (e.g. git worktrees) overwrote each other and broke cross-worker service-binding resolution. Quarry now deterministically resolves the registry to `<projectRoot>/.wrangler/registry`, keeping every process in a checkout in the same project-local registry.

- New `resolveDevRegistryPath()`: explicit `MINIFLARE_REGISTRY_PATH` / `WRANGLER_REGISTRY_PATH` wins, else `<projectRoot>/.wrangler/registry`, else `<cwd>/.wrangler/registry`
- New `findProjectRoot()`: nearest ancestor with a lockfile (immune to nested workspace `package.json`s and stray `.git` dirs), falling back to the outermost `package.json`
- Resolved path is exported as `MINIFLARE_REGISTRY_PATH` so spawned children (e.g. the vite dev server from `inertia:dev`) land in the identical registry

## How to Test

- `yarn workspace stratal test src/bin/__tests__/registry.spec.ts`
- Run `quarry` in a project with no registry env vars set — verify `.wrangler/registry` appears at the lockfile root, not `~/.wrangler/registry`
- Run two checkouts (e.g. git worktrees) in parallel — verify each gets its own registry
- Set `WRANGLER_REGISTRY_PATH=/tmp/custom` and run `quarry` — verify the override wins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable project-root detection by scanning for lockfiles and package metadata.
  * Deterministic dev-service registry path resolution with explicit environment variable overrides and sensible fallbacks.

* **Tests**
  * Added comprehensive tests covering project-root discovery and registry path resolution, including env-var precedence and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->