### PR TITLE
feat(framework): map SESSION_NOT_FRESH to FreshSessionRequiredError

### DIFF
--- a/packages/framework/src/auth/__tests__/better-auth-error-handler.spec.ts
+++ b/packages/framework/src/auth/__tests__/better-auth-error-handler.spec.ts
@@ -1,0 +1,24 @@
+import { APIError } from 'better-auth/api'
+import { describe, expect, it } from 'vitest'
+import { FreshSessionRequiredError, SessionExpiredError } from '../errors'
+import { mapBetterAuthError } from '../utils/better-auth-error-handler'
+
+describe('mapBetterAuthError', () => {
+  it('maps SESSION_NOT_FRESH to FreshSessionRequiredError', () => {
+    const error = new APIError('FORBIDDEN', { code: 'SESSION_NOT_FRESH', message: 'Session is not fresh' })
+
+    const mapped = mapBetterAuthError(error)
+
+    expect(mapped).toBeInstanceOf(FreshSessionRequiredError)
+    expect((mapped as FreshSessionRequiredError).httpStatus).toBe(403)
+  })
+
+  it('maps SESSION_EXPIRED to SessionExpiredError', () => {
+    const error = new APIError('UNAUTHORIZED', { code: 'SESSION_EXPIRED', message: 'Session expired' })
+
+    const mapped = mapBetterAuthError(error)
+
+    expect(mapped).toBeInstanceOf(SessionExpiredError)
+    expect((mapped as SessionExpiredError).httpStatus).toBe(401)
+  })
+})

--- a/packages/framework/src/auth/errors/auth-errors.ts
+++ b/packages/framework/src/auth/errors/auth-errors.ts
@@ -24,6 +24,10 @@ export class SessionExpiredError extends HttpException {
   constructor() { super(401, 'Session expired') }
 }
 
+export class FreshSessionRequiredError extends HttpException {
+  constructor() { super(403, 'Fresh session required') }
+}
+
 export class EmailNotVerifiedError extends HttpException {
   constructor(public readonly email?: string) {
     super(403, 'Email not verified')

--- a/packages/framework/src/auth/utils/better-auth-error-handler.ts
+++ b/packages/framework/src/auth/utils/better-auth-error-handler.ts
@@ -11,6 +11,7 @@ import {
   EmailCannotBeUpdatedError,
   EmailMismatchError,
   EmailNotVerifiedError,
+  FreshSessionRequiredError,
   IdTokenNotSupportedError,
   InvalidCallbackUrlError,
   InvalidCredentialsError,
@@ -73,7 +74,8 @@ export function mapBetterAuthError(error: APIError): ApplicationError {
   if (errorCode === 'INVALID_EMAIL') return new InvalidEmailError()
 
   // Session errors
-  if (errorCode === 'SESSION_EXPIRED' || errorCode === 'SESSION_NOT_FRESH') return new SessionExpiredError()
+  if (errorCode === 'SESSION_EXPIRED') return new SessionExpiredError()
+  if (errorCode === 'SESSION_NOT_FRESH') return new FreshSessionRequiredError()
   if (errorCode === 'FAILED_TO_CREATE_SESSION') return new AuthError('Failed to create session')
   if (errorCode === 'FAILED_TO_GET_SESSION') return new AuthError('Failed to retrieve session')
 


### PR DESCRIPTION
## Summary
Better Auth's `SESSION_NOT_FRESH` was conflated with `SESSION_EXPIRED` and mapped to `SessionExpiredError` (401), which misleads clients into re-authenticating when the session is still valid. It now maps to a new `FreshSessionRequiredError` (403) so clients can prompt for re-verification instead of a full sign-in.

## How to Test
- Run `yarn workspace @stratal/framework test better-auth-error-handler`
- Verify `SESSION_NOT_FRESH` maps to `FreshSessionRequiredError` with status 403
- Verify `SESSION_EXPIRED` still maps to `SessionExpiredError` with status 401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for authentication sessions to properly distinguish between expired sessions and sessions requiring refresh, returning appropriate HTTP status codes.

* **Tests**
  * Added test coverage for authentication error mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->