### PR TITLE
feat: support wrangler remote bindings in Quarry and harden feature-flag evaluation

### DIFF
--- a/.changeset/feature-flag-resilient-evaluation-feature-flags.md
+++ b/.changeset/feature-flag-resilient-evaluation-feature-flags.md
@@ -1,0 +1,7 @@
+---
+"@stratal/feature-flags": patch
+---
+
+Make feature flag evaluation resilient to runtime failures
+
+Flag evaluation now returns the fallback value and logs a warning if a lookup throws — for example when a remote-binding dev tunnel drops — rather than failing the request. Detail methods return an `ERROR` reason with the fallback in these cases.

--- a/.changeset/quarry-remote-proxy-session-core.md
+++ b/.changeset/quarry-remote-proxy-session-core.md
@@ -1,0 +1,7 @@
+---
+"stratal": patch
+---
+
+Support wrangler remote bindings in the Quarry dev runner
+
+Bindings marked `remote: true` in your `wrangler` config now connect to the deployed Cloudflare resources during local development, instead of resolving against the local dev registry. Plain local runs are unaffected. When a remote binding is in use, Quarry logs which bindings are being proxied and requires valid wrangler credentials (`wrangler login` or `CLOUDFLARE_API_TOKEN`).

--- a/packages/core/src/bin/quarry.ts
+++ b/packages/core/src/bin/quarry.ts
@@ -18,10 +18,20 @@ interface MiniflareWorkerResult {
   workerOptions: Record<string, unknown>
 }
 
+interface RemoteProxySessionData {
+  session: {
+    ready: Promise<unknown>
+    dispose: () => Promise<void>
+    remoteProxyConnectionString: unknown
+  }
+  remoteBindings: Record<string, unknown>
+}
+
 interface WranglerModule {
   unstable_readConfig: (args: { config?: string; env?: string }) => WranglerConfig
-  unstable_getMiniflareWorkerOptions: (config: WranglerConfig, env?: string) => MiniflareWorkerResult
+  unstable_getMiniflareWorkerOptions: (config: WranglerConfig, env?: string, options?: { remoteProxyConnectionString?: unknown }) => MiniflareWorkerResult
   unstable_getVarsForDev: (configPath: string | undefined, envFiles: undefined, vars: unknown, env: string | undefined) => Record<string, { value: string }>
+  maybeStartOrUpdateRemoteProxySession: (config: { path: string; environment?: string }) => Promise<RemoteProxySessionData | null>
 }
 
 interface MiniflareModule {
@@ -73,7 +83,7 @@ if (!existsSync(entryPath)) {
 async function main(): Promise<void> {
   const cwdRequire = createRequire(join(process.cwd(), 'package.json'))
 
-  const { unstable_readConfig: readConfig, unstable_getMiniflareWorkerOptions: getMiniflareWorkerOptions, unstable_getVarsForDev: getVarsForDev } = await import(cwdRequire.resolve('wrangler')) as WranglerModule
+  const { unstable_readConfig: readConfig, unstable_getMiniflareWorkerOptions: getMiniflareWorkerOptions, unstable_getVarsForDev: getVarsForDev, maybeStartOrUpdateRemoteProxySession } = await import(cwdRequire.resolve('wrangler')) as WranglerModule
   const { Miniflare } = await import(cwdRequire.resolve('miniflare')) as MiniflareModule
 
   const candidates = ['wrangler.jsonc', 'wrangler.json', 'wrangler.toml']
@@ -116,7 +126,26 @@ async function main(): Promise<void> {
   process.env.MINIFLARE_REGISTRY_PATH = registryPath
 
   const config = readConfig({ config: configPath, env: environment })
-  const { workerOptions } = getMiniflareWorkerOptions(config, environment)
+
+  // Honor `remote: true` bindings (wrangler remote bindings): start a proxy
+  // session against the deployed Cloudflare resources and thread its
+  // connection string into the Miniflare worker options, so e.g. a service
+  // binding marked remote calls the deployed worker instead of the local dev
+  // registry. Returns null when the resolved config declares no remote
+  // bindings — plain local runs are untouched. Requires wrangler credentials
+  // (`wrangler login` / CLOUDFLARE_API_TOKEN) when a session does start.
+  const remoteProxy = configPath
+    ? await maybeStartOrUpdateRemoteProxySession({ path: configPath, environment })
+    : null
+  if (remoteProxy) {
+    await remoteProxy.session.ready
+    const remoteNames = Object.keys(remoteProxy.remoteBindings)
+    console.log(`Remote bindings: proxying ${remoteNames.length} binding(s) to deployed resources (${remoteNames.join(', ')})`)
+  }
+
+  const { workerOptions } = getMiniflareWorkerOptions(config, environment, {
+    remoteProxyConnectionString: remoteProxy?.session.remoteProxyConnectionString,
+  })
 
   const vars = getVarsForDev(configPath, undefined, config.vars, environment)
   const varsRecord: Record<string, string> = {}
@@ -196,6 +225,7 @@ async function main(): Promise<void> {
     await Promise.allSettled(pendingPromises)
     await app?.shutdown()
     await mf.dispose()
+    await remoteProxy?.session.dispose()
   }
 }
 

--- a/packages/feature-flags/CLAUDE.md
+++ b/packages/feature-flags/CLAUDE.md
@@ -7,8 +7,11 @@ Maintainer rules for `@stratal/feature-flags`. Consumer API depth lives in
 
 - Wraps **only** the Cloudflare Flagship **binding API** (`env.FLAGS`). No
   OpenFeature SDK (`@cloudflare/flagship`), no HTTP/server-provider fallback.
-- The binding never throws — it returns the supplied `defaultValue` on error.
-  Don't add a second fallback layer.
+- Evaluation never throws. The binding returns the supplied `defaultValue` on
+  evaluation errors, and `FeatureFlagService` additionally catches transport-level
+  binding failures (e.g. a `remote: true` dev-proxy WebSocket tunnel dropping) and
+  returns the same fallback with a logged warning. Don't add a fallback layer in
+  consumers.
 
 ## Layout
 

--- a/packages/feature-flags/src/__tests__/feature-flag.service.spec.ts
+++ b/packages/feature-flags/src/__tests__/feature-flag.service.spec.ts
@@ -196,6 +196,24 @@ describe('FeatureFlagService', () => {
       const service = new FeatureFlagService(makeOptions(), makeEnv(flags, makeBinding()), undefined, undefined)
       expect(await service.getBooleanValue('new-checkout')).toBe(false)
     })
+
+    it('returns the fallback when the context resolver throws', async () => {
+      const ctxBoom = () => {
+        throw new Error('context resolver failed')
+      }
+      const { service, flags } = setup({ context: ctxBoom }, {} as RouterContext)
+      expect(await service.getStringValue('checkout-flow')).toBe('v1')
+      expect(flags.getStringValue).not.toHaveBeenCalled()
+    })
+
+    it('returns the manifest defaults when the context resolver throws in all()', async () => {
+      const ctxBoom = () => {
+        throw new Error('context resolver failed')
+      }
+      const { service, flags } = setup({ context: ctxBoom }, {} as RouterContext)
+      expect(await service.all()).toEqual({ 'new-checkout': false, 'checkout-flow': 'v1', 'max-uploads': 5 })
+      expect(flags.getBooleanValue).not.toHaveBeenCalled()
+    })
   })
 
   describe('DI resolution', () => {

--- a/packages/feature-flags/src/__tests__/feature-flag.service.spec.ts
+++ b/packages/feature-flags/src/__tests__/feature-flag.service.spec.ts
@@ -1,4 +1,6 @@
+import type { StratalEnv } from 'stratal'
 import { Container, DI_TOKENS } from 'stratal/di'
+import { JsonFormatter, LogLevel, LoggerService } from 'stratal/logger'
 import { ROUTER_TOKENS, type RouterContext } from 'stratal/router'
 import { describe, expect, it, vi } from 'vitest'
 import { FeatureFlagError } from '../feature-flags.error'
@@ -21,6 +23,28 @@ function makeBinding() {
   }
 }
 
+type FlagshipDouble = ReturnType<typeof makeBinding>
+
+// The documented consumer pattern (see stratal's env.ts): augment StratalEnv with
+// the bindings the suite uses, so test envs type-check instead of being cast away.
+declare module 'stratal' {
+  interface StratalEnv {
+    FLAGS: FlagshipDouble
+    EXPERIMENT_FLAGS: FlagshipDouble
+  }
+}
+
+function makeEnv(flags: FlagshipDouble, experiment: FlagshipDouble): StratalEnv {
+  return { ENVIRONMENT: 'test', CACHE: {} as KVNamespace, FLAGS: flags, EXPERIMENT_FLAGS: experiment }
+}
+
+/** A real LoggerService with `warn` spied and silenced. */
+function makeLogger() {
+  const logger = new LoggerService(LogLevel.WARN, new JsonFormatter())
+  vi.spyOn(logger, 'warn').mockReturnValue(undefined)
+  return logger
+}
+
 function makeOptions(options: Partial<FeatureFlagModuleOptions> = {}): FeatureFlagModuleOptions {
   return {
     apps: [
@@ -35,9 +59,9 @@ function makeOptions(options: Partial<FeatureFlagModuleOptions> = {}): FeatureFl
 function setup(options: Partial<FeatureFlagModuleOptions> = {}, ctx: RouterContext | undefined = undefined) {
   const flags = makeBinding()
   const experiment = makeBinding()
-  const env = { FLAGS: flags, EXPERIMENT_FLAGS: experiment } as never
-  const service = new FeatureFlagService(makeOptions(options), env, ctx)
-  return { service, flags, experiment }
+  const logger = makeLogger()
+  const service = new FeatureFlagService(makeOptions(options), makeEnv(flags, experiment), ctx, logger)
+  return { service, flags, experiment, logger }
 }
 
 describe('FeatureFlagService', () => {
@@ -110,9 +134,68 @@ describe('FeatureFlagService', () => {
 
   it('throws when the configured binding is missing from the environment', () => {
     expect(() =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- env intentionally missing the binding
-      new FeatureFlagService({ apps: [{ binding: 'FLAGS' }] }, {} as any, undefined),
+      // env intentionally missing the FLAGS binding
+      new FeatureFlagService({ apps: [{ binding: 'FLAGS' }] }, { ENVIRONMENT: 'test', CACHE: {} as KVNamespace } as StratalEnv, undefined, undefined),
     ).toThrow(FeatureFlagError)
+  })
+
+  describe('binding failure resilience', () => {
+    const tunnelDown = new Error('WebSocket connection failed.')
+
+    it('returns the explicit default when the binding rejects', async () => {
+      const { service, flags } = setup()
+      flags.getBooleanValue.mockRejectedValueOnce(tunnelDown)
+      expect(await service.getBooleanValue('new-checkout', true)).toBe(true)
+    })
+
+    it('returns the manifest default when the binding rejects and no default is provided', async () => {
+      const { service, flags } = setup()
+      flags.getStringValue.mockRejectedValueOnce(tunnelDown)
+      expect(await service.getStringValue('checkout-flow')).toBe('v1')
+    })
+
+    it("returns the type's zero value when the binding rejects for an undeclared flag", async () => {
+      const { service, flags } = setup()
+      flags.getNumberValue.mockRejectedValueOnce(tunnelDown)
+      expect(await service.getNumberValue('not-in-manifest')).toBe(0)
+    })
+
+    it('synthesizes error details when a details evaluation rejects', async () => {
+      const { service, flags } = setup()
+      flags.getBooleanDetails.mockRejectedValueOnce(tunnelDown)
+      expect(await service.getBooleanDetails('new-checkout')).toEqual({
+        flagKey: 'new-checkout',
+        value: false,
+        reason: 'ERROR',
+        errorMessage: 'WebSocket connection failed.',
+      })
+    })
+
+    it('falls back to the manifest map when the binding rejects in all()', async () => {
+      const { service, flags } = setup()
+      flags.getBooleanValue.mockRejectedValue(tunnelDown)
+      flags.getStringValue.mockRejectedValue(tunnelDown)
+      flags.getNumberValue.mockRejectedValue(tunnelDown)
+      expect(await service.all()).toEqual({ 'new-checkout': false, 'checkout-flow': 'v1', 'max-uploads': 5 })
+    })
+
+    it('logs a warning per failed evaluation', async () => {
+      const { service, flags, logger } = setup()
+      flags.getBooleanValue.mockRejectedValueOnce(tunnelDown)
+      await service.getBooleanValue('new-checkout')
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('"new-checkout"'),
+        { error: 'WebSocket connection failed.' },
+      )
+    })
+
+    it('survives a rejecting binding without a logger', async () => {
+      const flags = makeBinding()
+      flags.getBooleanValue.mockRejectedValueOnce(tunnelDown)
+      const service = new FeatureFlagService(makeOptions(), makeEnv(flags, makeBinding()), undefined, undefined)
+      expect(await service.getBooleanValue('new-checkout')).toBe(false)
+    })
   })
 
   describe('DI resolution', () => {
@@ -121,7 +204,7 @@ describe('FeatureFlagService', () => {
       const flags = makeBinding()
       const c = new Container()
       c.registerValue(FEATURE_FLAG_TOKENS.Options, makeOptions(options))
-      c.registerValue(DI_TOKENS.CloudflareEnv, { FLAGS: flags } as never)
+      c.registerValue(DI_TOKENS.CloudflareEnv, makeEnv(flags, makeBinding()))
       c.register(FEATURE_FLAG_TOKENS.FeatureFlagService, FeatureFlagService)
       return { c, flags }
     }

--- a/packages/feature-flags/src/services/feature-flag.service.ts
+++ b/packages/feature-flags/src/services/feature-flag.service.ts
@@ -83,64 +83,55 @@ export class FeatureFlagService {
   /** Returns the raw flag value without type checking. */
   async get(flagKey: string, defaultValue?: unknown, context?: FlagshipEvaluationContext): Promise<unknown> {
     const fallback = this.fallback(flagKey, defaultValue)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.get(flagKey, fallback, merged), () => fallback)
+    return this.safe(flagKey, async () => this.binding.get(flagKey, fallback, await this.context(context)), () => fallback)
   }
 
   /** Returns the flag value as a `boolean`. */
   async getBooleanValue(flagKey: string, defaultValue?: boolean, context?: FlagshipEvaluationContext): Promise<boolean> {
     const fallback = this.fallback(flagKey, defaultValue, false)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getBooleanValue(flagKey, fallback, merged), () => fallback)
+    return this.safe(flagKey, async () => this.binding.getBooleanValue(flagKey, fallback, await this.context(context)), () => fallback)
   }
 
   /** Returns the flag value as a `string`. */
   async getStringValue(flagKey: string, defaultValue?: string, context?: FlagshipEvaluationContext): Promise<string> {
     const fallback = this.fallback(flagKey, defaultValue, '')
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getStringValue(flagKey, fallback, merged), () => fallback)
+    return this.safe(flagKey, async () => this.binding.getStringValue(flagKey, fallback, await this.context(context)), () => fallback)
   }
 
   /** Returns the flag value as a `number`. */
   async getNumberValue(flagKey: string, defaultValue?: number, context?: FlagshipEvaluationContext): Promise<number> {
     const fallback = this.fallback(flagKey, defaultValue, 0)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getNumberValue(flagKey, fallback, merged), () => fallback)
+    return this.safe(flagKey, async () => this.binding.getNumberValue(flagKey, fallback, await this.context(context)), () => fallback)
   }
 
   /** Returns the flag value as a typed object. */
   async getObjectValue<T extends object>(flagKey: string, defaultValue?: T, context?: FlagshipEvaluationContext): Promise<T> {
     const fallback = this.fallback(flagKey, defaultValue, {} as T)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getObjectValue<T>(flagKey, fallback, merged), () => fallback)
+    return this.safe(flagKey, async () => this.binding.getObjectValue<T>(flagKey, fallback, await this.context(context)), () => fallback)
   }
 
   /** Returns the `boolean` flag value with evaluation metadata. */
   async getBooleanDetails(flagKey: string, defaultValue?: boolean, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<boolean>> {
     const fallback = this.fallback(flagKey, defaultValue, false)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getBooleanDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
+    return this.safe(flagKey, async () => this.binding.getBooleanDetails(flagKey, fallback, await this.context(context)), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the `string` flag value with evaluation metadata. */
   async getStringDetails(flagKey: string, defaultValue?: string, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<string>> {
     const fallback = this.fallback(flagKey, defaultValue, '')
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getStringDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
+    return this.safe(flagKey, async () => this.binding.getStringDetails(flagKey, fallback, await this.context(context)), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the `number` flag value with evaluation metadata. */
   async getNumberDetails(flagKey: string, defaultValue?: number, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<number>> {
     const fallback = this.fallback(flagKey, defaultValue, 0)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getNumberDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
+    return this.safe(flagKey, async () => this.binding.getNumberDetails(flagKey, fallback, await this.context(context)), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the typed object flag value with evaluation metadata. */
   async getObjectDetails<T extends object>(flagKey: string, defaultValue?: T, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<T>> {
     const fallback = this.fallback(flagKey, defaultValue, {} as T)
-    const merged = await this.context(context)
-    return this.safe(flagKey, () => this.binding.getObjectDetails<T>(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
+    return this.safe(flagKey, async () => this.binding.getObjectDetails<T>(flagKey, fallback, await this.context(context)), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /**
@@ -149,8 +140,17 @@ export class FeatureFlagService {
    * default's type. Powers `FeatureFlagShareMiddleware`.
    */
   async all(context?: FlagshipEvaluationContext): Promise<Record<string, FlagValue>> {
-    const merged = await this.context(context)
     const keys = Object.keys(this.manifest)
+    // Resolve the shared context once. A throwing resolver must not take the
+    // batch down — fall back to the manifest defaults, the same values each
+    // per-flag method returns when evaluation can't proceed.
+    let merged: FlagshipEvaluationContext | undefined
+    try {
+      merged = await this.context(context)
+    } catch (error) {
+      this.logger?.warn(`Feature flag context resolution failed on app "${this.bindingName}"; returning manifest defaults.`, { error: this.message(error) })
+      return { ...this.manifest }
+    }
     const values = await Promise.all(keys.map((key) => this.evaluate(key, this.manifest[key], merged)))
     const result: Record<string, FlagValue> = {}
     keys.forEach((key, i) => {
@@ -217,7 +217,7 @@ export class FeatureFlagService {
       return await evaluate()
     } catch (error) {
       this.logger?.warn(`Feature flag evaluation failed for "${flagKey}" on app "${this.bindingName}"; returning the fallback value.`, {
-        error: error instanceof Error ? error.message : String(error),
+        error: this.message(error),
       })
       return onError(error)
     }
@@ -225,6 +225,11 @@ export class FeatureFlagService {
 
   /** Synthesizes the details shape the binding would return for a failed evaluation. */
   private errorDetails<T>(flagKey: string, value: T, error: unknown): FlagshipEvaluationDetails<T> {
-    return { flagKey, value, reason: 'ERROR', errorMessage: error instanceof Error ? error.message : String(error) }
+    return { flagKey, value, reason: 'ERROR', errorMessage: this.message(error) }
+  }
+
+  /** Extracts a human-readable message from an unknown thrown value. */
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error)
   }
 }

--- a/packages/feature-flags/src/services/feature-flag.service.ts
+++ b/packages/feature-flags/src/services/feature-flag.service.ts
@@ -1,5 +1,6 @@
 import type { StratalEnv } from 'stratal'
 import { DI_TOKENS, Transient, inject } from 'stratal/di'
+import { LOGGER_TOKENS, type LoggerService } from 'stratal/logger'
 import { ROUTER_TOKENS, type RouterContext } from 'stratal/router'
 import { FeatureFlagError } from '../feature-flags.error'
 import { FEATURE_FLAG_TOKENS } from '../feature-flags.tokens'
@@ -23,8 +24,10 @@ import type {
  *   evaluation (per-call context overrides it). Resolved from the current
  *   request; skipped automatically outside request scope.
  *
- * Switch to another Flagship app with {@link use}. Evaluation never throws — the
- * binding returns the default value on error.
+ * Switch to another Flagship app with {@link use}. Evaluation never throws —
+ * the binding returns the default value on evaluation errors, and the service
+ * catches everything else (e.g. a dropped remote-binding tunnel in local dev)
+ * and returns the same fallback, logging a warning.
  *
  * @example
  * ```typescript
@@ -48,6 +51,7 @@ export class FeatureFlagService {
     @inject(FEATURE_FLAG_TOKENS.Options) private readonly options: FeatureFlagModuleOptions,
     @inject(DI_TOKENS.CloudflareEnv) private readonly env: StratalEnv,
     @inject(ROUTER_TOKENS.RouterContext, { isOptional: true }) private readonly routerContext: RouterContext | undefined,
+    @inject(LOGGER_TOKENS.LoggerService, { isOptional: true }) private readonly logger: LoggerService | undefined,
     // Only passed by `use()`; DI never injects it. Lets `use()` bind exactly once
     // instead of binding to the default in the constructor and re-binding after.
     initialBinding?: string,
@@ -66,7 +70,7 @@ export class FeatureFlagService {
    */
   use(binding: FlagshipBindingName): FeatureFlagService {
     if (binding === this.bindingName) return this
-    return new FeatureFlagService(this.options, this.env, this.routerContext, binding)
+    return new FeatureFlagService(this.options, this.env, this.routerContext, this.logger, binding)
   }
 
   /** The binding name this instance currently targets. */
@@ -78,47 +82,65 @@ export class FeatureFlagService {
 
   /** Returns the raw flag value without type checking. */
   async get(flagKey: string, defaultValue?: unknown, context?: FlagshipEvaluationContext): Promise<unknown> {
-    return this.binding.get(flagKey, this.fallback(flagKey, defaultValue), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.get(flagKey, fallback, merged), () => fallback)
   }
 
   /** Returns the flag value as a `boolean`. */
   async getBooleanValue(flagKey: string, defaultValue?: boolean, context?: FlagshipEvaluationContext): Promise<boolean> {
-    return this.binding.getBooleanValue(flagKey, this.fallback(flagKey, defaultValue, false), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, false)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getBooleanValue(flagKey, fallback, merged), () => fallback)
   }
 
   /** Returns the flag value as a `string`. */
   async getStringValue(flagKey: string, defaultValue?: string, context?: FlagshipEvaluationContext): Promise<string> {
-    return this.binding.getStringValue(flagKey, this.fallback(flagKey, defaultValue, ''), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, '')
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getStringValue(flagKey, fallback, merged), () => fallback)
   }
 
   /** Returns the flag value as a `number`. */
   async getNumberValue(flagKey: string, defaultValue?: number, context?: FlagshipEvaluationContext): Promise<number> {
-    return this.binding.getNumberValue(flagKey, this.fallback(flagKey, defaultValue, 0), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, 0)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getNumberValue(flagKey, fallback, merged), () => fallback)
   }
 
   /** Returns the flag value as a typed object. */
   async getObjectValue<T extends object>(flagKey: string, defaultValue?: T, context?: FlagshipEvaluationContext): Promise<T> {
-    return this.binding.getObjectValue<T>(flagKey, this.fallback(flagKey, defaultValue, {} as T), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, {} as T)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getObjectValue<T>(flagKey, fallback, merged), () => fallback)
   }
 
   /** Returns the `boolean` flag value with evaluation metadata. */
   async getBooleanDetails(flagKey: string, defaultValue?: boolean, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<boolean>> {
-    return this.binding.getBooleanDetails(flagKey, this.fallback(flagKey, defaultValue, false), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, false)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getBooleanDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the `string` flag value with evaluation metadata. */
   async getStringDetails(flagKey: string, defaultValue?: string, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<string>> {
-    return this.binding.getStringDetails(flagKey, this.fallback(flagKey, defaultValue, ''), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, '')
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getStringDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the `number` flag value with evaluation metadata. */
   async getNumberDetails(flagKey: string, defaultValue?: number, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<number>> {
-    return this.binding.getNumberDetails(flagKey, this.fallback(flagKey, defaultValue, 0), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, 0)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getNumberDetails(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /** Returns the typed object flag value with evaluation metadata. */
   async getObjectDetails<T extends object>(flagKey: string, defaultValue?: T, context?: FlagshipEvaluationContext): Promise<FlagshipEvaluationDetails<T>> {
-    return this.binding.getObjectDetails<T>(flagKey, this.fallback(flagKey, defaultValue, {} as T), await this.context(context))
+    const fallback = this.fallback(flagKey, defaultValue, {} as T)
+    const merged = await this.context(context)
+    return this.safe(flagKey, () => this.binding.getObjectDetails<T>(flagKey, fallback, merged), (error) => this.errorDetails(flagKey, fallback, error))
   }
 
   /**
@@ -174,13 +196,35 @@ export class FeatureFlagService {
   private evaluate(flagKey: string, declared: FlagValue, context?: FlagshipEvaluationContext): Promise<FlagValue> {
     switch (typeof declared) {
       case 'boolean':
-        return this.binding.getBooleanValue(flagKey, declared, context)
+        return this.safe(flagKey, () => this.binding.getBooleanValue(flagKey, declared, context), () => declared)
       case 'number':
-        return this.binding.getNumberValue(flagKey, declared, context)
+        return this.safe(flagKey, () => this.binding.getNumberValue(flagKey, declared, context), () => declared)
       case 'string':
-        return this.binding.getStringValue(flagKey, declared, context)
+        return this.safe(flagKey, () => this.binding.getStringValue(flagKey, declared, context), () => declared)
       default:
-        return this.binding.getObjectValue(flagKey, declared, context)
+        return this.safe(flagKey, () => this.binding.getObjectValue(flagKey, declared, context), () => declared)
     }
+  }
+
+  /**
+   * Runs an evaluation and absorbs any failure into the fallback. The binding
+   * already returns the default on evaluation errors, but the call itself can
+   * still reject — e.g. when a `remote: true` binding's dev-proxy WebSocket
+   * tunnel drops. A flag lookup must never take the request down with it.
+   */
+  private async safe<T>(flagKey: string, evaluate: () => Promise<T>, onError: (error: unknown) => T): Promise<T> {
+    try {
+      return await evaluate()
+    } catch (error) {
+      this.logger?.warn(`Feature flag evaluation failed for "${flagKey}" on app "${this.bindingName}"; returning the fallback value.`, {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return onError(error)
+    }
+  }
+
+  /** Synthesizes the details shape the binding would return for a failed evaluation. */
+  private errorDetails<T>(flagKey: string, value: T, error: unknown): FlagshipEvaluationDetails<T> {
+    return { flagKey, value, reason: 'ERROR', errorMessage: error instanceof Error ? error.message : String(error) }
   }
 }


### PR DESCRIPTION
## Summary
Adds wrangler remote-binding support to the Quarry dev runner so `remote: true` bindings hit deployed Cloudflare resources during local dev, and hardens `@stratal/feature-flags` so a dropped remote-binding tunnel (or any binding-level failure) returns the fallback instead of taking down the request.

## How to Test
- Mark a binding `remote: true` in `wrangler` config, run Quarry dev — confirm it logs the proxied binding(s) and calls the deployed resource.
- Run a plain local Quarry dev (no remote bindings) — confirm behavior is unchanged.
- `yarn workspace @stratal/feature-flags test` — covers binding rejection, manifest/zero-value fallbacks, `ERROR`-reason details, `all()`, and warning logging.
- Simulate a failing flag lookup (tunnel drop) — confirm fallback returned and a warning logged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Wrangler "remote" bindings, enabling proxying to deployed resources.

* **Improvements**
  * Feature flag evaluation now gracefully handles binding failures by returning default values.
  * Added warning logs for feature flag evaluation errors.

* **Documentation**
  * Clarified that feature flag evaluation never throws and reliably returns fallback values on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->